### PR TITLE
postfix 2.10.2 に更新

### DIFF
--- a/plamo/01_minimum/network.txz/postfix/PlamoBuild.postfix-2.10.2
+++ b/plamo/01_minimum/network.txz/postfix/PlamoBuild.postfix-2.10.2
@@ -1,13 +1,12 @@
 #!/bin/sh
 ##############################################################
-url='http://mirror.postfix.jp/postfix-release/official/postfix-2.10.1.tar.gz'
+url='http://mirror.postfix.jp/postfix-release/official/postfix-2.10.2.tar.gz'
 verify=$url.sig
 pkgbase=postfix
-vers=2.10.1
-arch=x86_64
-# arch=i586
+vers=2.10.2
+arch=`uname -m | sed -e 's/i.86/i586/'`
 build=P1
-src=postfix-2.10.1
+src=${pkgbase}-${vers}
 OPT_CONFIG=''
 DOCS='HISTORY IPv6-ChangeLog LICENSE RELEASE_NOTES-1.0 RELEASE_NOTES-1.1 RELEASE_NOTES-2.0 RELEASE_NOTES-2.1 RELEASE_NOTES-2.2 RELEASE_NOTES-2.3 RELEASE_NOTES-2.4 RELEASE_NOTES-2.5 RELEASE_NOTES-2.6 RELEASE_NOTES-2.7 RELEASE_NOTES-2.8 RELEASE_NOTES-2.9 TLS_TODO pflogsumm_quickfix.txt postfix-install'
 patchfiles=''


### PR DESCRIPTION
- postfix 2.10.1 -> 2.10.2
- $arch の自動検出
- Ver.up 時に $src を書き換えなくても良いようにした
