### PR TITLE
contrib/Virtualization/lxc: lxc-plamo の改良

### DIFF
--- a/contrib/Virtualization/lxc/lxc-plamo
+++ b/contrib/Virtualization/lxc/lxc-plamo
@@ -254,10 +254,6 @@ copy_configuration() {
 	# fuse
 	lxc.cgroup.devices.allow = c 10:229 rwm
 	EOF
-  cat <<- EOF > $path/fstab || let ret++
-	proc	$path/rootfs/proc	proc	nodev,noexec,nosuid	0	0
-	sysfs	$path/rootfs/sys	sysfs	defaults	0	0
-	EOF
   if [ $ret -ne 0 ] ; then
     echo "Failed to add configuration."
     return 1


### PR DESCRIPTION
- kernel パッケージをインストール対象から外す
- コンテナの config で lxc.mount.auto を使い proc, sys, cgroup をマウントするように変更
