### PR TITLE
plamo/00_base/dhcp: VM (kvm,xen,lxc) 上で dhcp を使う場合のエラーの回避

### DIFF
--- a/plamo/00_base/dhcp/PlamoBuild.dhcp-4.2.5-P1
+++ b/plamo/00_base/dhcp/PlamoBuild.dhcp-4.2.5-P1
@@ -4,13 +4,12 @@ url='http://ftp.isc.org/isc/dhcp/4.2.5-P1/dhcp-4.2.5-P1.tar.gz'
 verify=$url.asc
 pkgbase=dhcp
 vers=4.2.5_P1
-arch=x86_64
-# arch=i586
-build=P1
+arch=`uname -m | sed -e 's/i.86/i586/'`
+build=P2
 src=dhcp-4.2.5-P1
 OPT_CONFIG=''
 DOCS='LICENSE README'
-patchfiles='dhcp-4.2.0-scripts.patch'
+patchfiles='dhcp-4.2.0-scripts.patch udp_checksum_offloading dhcp-ffff-checksum.patch'
 compress=txz
 ##############################################################
 
@@ -196,7 +195,7 @@ if [ $opt_build -eq 1 ] ; then
     cd ${B[$i]}
     if [ -f Makefile ] ; then
       export LDFLAGS='-Wl,--as-needed'
-      make -j3
+      make
     fi
   done
 fi

--- a/plamo/00_base/dhcp/dhcp-ffff-checksum.patch
+++ b/plamo/00_base/dhcp/dhcp-ffff-checksum.patch
@@ -1,0 +1,12 @@
+diff -up dhcp-4.2.5/common/packet.c.ffff dhcp-4.2.5/common/packet.c
+--- dhcp-4.2.5/common/packet.c.ffff	2013-10-07 17:21:18.000000000 +0200
++++ dhcp-4.2.5/common/packet.c	2013-10-07 17:47:34.689600497 +0200
+@@ -326,6 +326,7 @@ decode_udp_ip_header(struct interface_in
+   len = ulen - sizeof(udp);
+ 
+   usum = udp.uh_sum;
++  if (usum == 0xffff) usum = 0;
+   udp.uh_sum = 0;
+ 
+   /* XXX: We have to pass &udp, because we have to zero the checksum
+

--- a/plamo/00_base/dhcp/udp_checksum_offloading
+++ b/plamo/00_base/dhcp/udp_checksum_offloading
@@ -1,0 +1,249 @@
+diff -uNr dhcp-4.2.5-P1.orig/common/bpf.c dhcp-4.2.5-P1/common/bpf.c
+--- dhcp-4.2.5-P1.orig/common/bpf.c	2013-03-06 03:26:51.000000000 +0900
++++ dhcp-4.2.5-P1/common/bpf.c	2013-10-16 15:34:32.626860658 +0900
+@@ -485,7 +485,7 @@
+ 		offset = decode_udp_ip_header (interface,
+ 					       interface -> rbuf,
+ 					       interface -> rbuf_offset,
+-  					       from, hdr.bh_caplen, &paylen);
++  					       from, hdr.bh_caplen, &paylen, 0);
+ 
+ 		/* If the IP or UDP checksum was bad, skip the packet... */
+ 		if (offset < 0) {
+diff -uNr dhcp-4.2.5-P1.orig/common/dlpi.c dhcp-4.2.5-P1/common/dlpi.c
+--- dhcp-4.2.5-P1.orig/common/dlpi.c	2013-01-24 02:04:59.000000000 +0900
++++ dhcp-4.2.5-P1/common/dlpi.c	2013-10-16 15:34:32.626860658 +0900
+@@ -693,7 +693,7 @@
+ 	length -= offset;
+ #endif
+ 	offset = decode_udp_ip_header (interface, dbuf, bufix,
+-				       from, length, &paylen);
++				       from, length, &paylen, 0);
+ 
+ 	/*
+ 	 * If the IP or UDP checksum was bad, skip the packet...
+diff -uNr dhcp-4.2.5-P1.orig/common/lpf.c dhcp-4.2.5-P1/common/lpf.c
+--- dhcp-4.2.5-P1.orig/common/lpf.c	2013-03-06 03:26:51.000000000 +0900
++++ dhcp-4.2.5-P1/common/lpf.c	2013-10-16 15:34:32.626860658 +0900
+@@ -30,19 +30,33 @@
+ #include "dhcpd.h"
+ #if defined (USE_LPF_SEND) || defined (USE_LPF_RECEIVE)
+ #include <sys/ioctl.h>
++#include <sys/socket.h>
+ #include <sys/uio.h>
+ #include <errno.h>
+ 
+ #include <asm/types.h>
+ #include <linux/filter.h>
+ #include <linux/if_ether.h>
++#include <linux/if_packet.h>
+ #include <netinet/in_systm.h>
+-#include <net/if_packet.h>
+ #include "includes/netinet/ip.h"
+ #include "includes/netinet/udp.h"
+ #include "includes/netinet/if_ether.h"
+ #include <net/if.h>
+ 
++#ifndef PACKET_AUXDATA
++#define PACKET_AUXDATA 8
++
++struct tpacket_auxdata
++{
++	__u32		tp_status;
++	__u32		tp_len;
++	__u32		tp_snaplen;
++	__u16		tp_mac;
++	__u16		tp_net;
++};
++#endif
++
+ /* Reinitializes the specified interface after an address change.   This
+    is not required for packet-filter APIs. */
+ 
+@@ -68,10 +82,14 @@
+ 	struct interface_info *info;
+ {
+ 	int sock;
+-	struct sockaddr sa;
++	union {
++		struct sockaddr_ll ll;
++		struct sockaddr common;
++	} sa;
++	struct ifreq ifr;
+ 
+ 	/* Make an LPF socket. */
+-	if ((sock = socket(PF_PACKET, SOCK_PACKET,
++	if ((sock = socket(PF_PACKET, SOCK_RAW,
+ 			   htons((short)ETH_P_ALL))) < 0) {
+ 		if (errno == ENOPROTOOPT || errno == EPROTONOSUPPORT ||
+ 		    errno == ESOCKTNOSUPPORT || errno == EPFNOSUPPORT ||
+@@ -86,11 +104,17 @@
+ 		log_fatal ("Open a socket for LPF: %m");
+ 	}
+ 
++	memset (&ifr, 0, sizeof ifr);
++	strncpy (ifr.ifr_name, (const char *)info -> ifp, sizeof ifr.ifr_name);
++	ifr.ifr_name[IFNAMSIZ-1] = '\0';
++	if (ioctl (sock, SIOCGIFINDEX, &ifr))
++		log_fatal ("Failed to get interface index: %m");
++
+ 	/* Bind to the interface name */
+ 	memset (&sa, 0, sizeof sa);
+-	sa.sa_family = AF_PACKET;
+-	strncpy (sa.sa_data, (const char *)info -> ifp, sizeof sa.sa_data);
+-	if (bind (sock, &sa, sizeof sa)) {
++	sa.ll.sll_family = AF_PACKET;
++	sa.ll.sll_ifindex = ifr.ifr_ifindex;
++	if (bind (sock, &sa.common, sizeof sa)) {
+ 		if (errno == ENOPROTOOPT || errno == EPROTONOSUPPORT ||
+ 		    errno == ESOCKTNOSUPPORT || errno == EPFNOSUPPORT ||
+ 		    errno == EAFNOSUPPORT || errno == EINVAL) {
+@@ -172,9 +196,18 @@
+ void if_register_receive (info)
+ 	struct interface_info *info;
+ {
++	int val;
++
+ 	/* Open a LPF device and hang it on this interface... */
+ 	info -> rfdesc = if_register_lpf (info);
+ 
++	val = 1;
++	if (setsockopt (info -> rfdesc, SOL_PACKET, PACKET_AUXDATA, &val,
++			sizeof val) < 0) {
++		if (errno != ENOPROTOOPT)
++			log_fatal ("Failed to set auxiliary packet data: %m");
++	}
++
+ #if defined (HAVE_TR_SUPPORT)
+ 	if (info -> hw_address.hbuf [0] == HTYPE_IEEE802)
+ 		lpf_tr_filter_setup (info);
+@@ -296,7 +329,6 @@
+ 	double hh [16];
+ 	double ih [1536 / sizeof (double)];
+ 	unsigned char *buf = (unsigned char *)ih;
+-	struct sockaddr_pkt sa;
+ 	int result;
+ 	int fudge;
+ 
+@@ -317,17 +349,7 @@
+ 				(unsigned char *)raw, len);
+ 	memcpy (buf + ibufp, raw, len);
+ 
+-	/* For some reason, SOCK_PACKET sockets can't be connected,
+-	   so we have to do a sentdo every time. */
+-	memset (&sa, 0, sizeof sa);
+-	sa.spkt_family = AF_PACKET;
+-	strncpy ((char *)sa.spkt_device,
+-		 (const char *)interface -> ifp, sizeof sa.spkt_device);
+-	sa.spkt_protocol = htons(ETH_P_IP);
+-
+-	result = sendto (interface -> wfdesc,
+-			 buf + fudge, ibufp + len - fudge, 0, 
+-			 (const struct sockaddr *)&sa, sizeof sa);
++	result = write (interface -> wfdesc, buf + fudge, ibufp + len - fudge);
+ 	if (result < 0)
+ 		log_error ("send_packet: %m");
+ 	return result;
+@@ -344,14 +366,35 @@
+ {
+ 	int length = 0;
+ 	int offset = 0;
++	int nocsum = 0;
+ 	unsigned char ibuf [1536];
+ 	unsigned bufix = 0;
+ 	unsigned paylen;
++	unsigned char cmsgbuf[CMSG_LEN(sizeof(struct tpacket_auxdata))];
++	struct iovec iov = {
++		.iov_base = ibuf,
++		.iov_len = sizeof ibuf,
++	};
++	struct msghdr msg = {
++		.msg_iov = &iov,
++		.msg_iovlen = 1,
++		.msg_control = cmsgbuf,
++		.msg_controllen = sizeof(cmsgbuf),
++	};
++	struct cmsghdr *cmsg;
+ 
+-	length = read (interface -> rfdesc, ibuf, sizeof ibuf);
++	length = recvmsg (interface -> rfdesc, &msg, 0);
+ 	if (length <= 0)
+ 		return length;
+ 
++	for (cmsg = CMSG_FIRSTHDR(&msg); cmsg; cmsg = CMSG_NXTHDR(&msg, cmsg)) {
++		if (cmsg->cmsg_level == SOL_PACKET &&
++		    cmsg->cmsg_type == PACKET_AUXDATA) {
++			struct tpacket_auxdata *aux = (void *)CMSG_DATA(cmsg);
++			nocsum = aux->tp_status & TP_STATUS_CSUMNOTREADY;
++		}
++	}
++
+ 	bufix = 0;
+ 	/* Decode the physical header... */
+ 	offset = decode_hw_header (interface, ibuf, bufix, hfrom);
+@@ -368,7 +411,7 @@
+ 
+ 	/* Decode the IP and UDP headers... */
+ 	offset = decode_udp_ip_header (interface, ibuf, bufix, from,
+-				       (unsigned)length, &paylen);
++				       (unsigned)length, &paylen, nocsum);
+ 
+ 	/* If the IP or UDP checksum was bad, skip the packet... */
+ 	if (offset < 0)
+diff -uNr dhcp-4.2.5-P1.orig/common/nit.c dhcp-4.2.5-P1/common/nit.c
+--- dhcp-4.2.5-P1.orig/common/nit.c	2013-01-24 02:04:59.000000000 +0900
++++ dhcp-4.2.5-P1/common/nit.c	2013-10-16 15:34:32.626860658 +0900
+@@ -369,7 +369,7 @@
+ 
+ 	/* Decode the IP and UDP headers... */
+ 	offset = decode_udp_ip_header (interface, ibuf, bufix,
+-				       from, length, &paylen);
++				       from, length, &paylen, 0);
+ 
+ 	/* If the IP or UDP checksum was bad, skip the packet... */
+ 	if (offset < 0)
+diff -uNr dhcp-4.2.5-P1.orig/common/packet.c dhcp-4.2.5-P1/common/packet.c
+--- dhcp-4.2.5-P1.orig/common/packet.c	2013-03-05 03:35:08.000000000 +0900
++++ dhcp-4.2.5-P1/common/packet.c	2013-10-16 15:34:32.630194083 +0900
+@@ -226,7 +226,7 @@
+ decode_udp_ip_header(struct interface_info *interface,
+ 		     unsigned char *buf, unsigned bufix,
+ 		     struct sockaddr_in *from, unsigned buflen,
+-		     unsigned *rbuflen)
++		     unsigned *rbuflen, int nocsum)
+ {
+   unsigned char *data;
+   struct ip ip;
+@@ -337,7 +337,7 @@
+ 					   8, IPPROTO_UDP + ulen))));
+ 
+   udp_packets_seen++;
+-  if (usum && usum != sum) {
++  if (!nocsum && usum && usum != sum) {
+ 	  udp_packets_bad_checksum++;
+ 	  if (udp_packets_seen > 4 &&
+ 	      (udp_packets_seen / udp_packets_bad_checksum) < 2) {
+diff -uNr dhcp-4.2.5-P1.orig/common/upf.c dhcp-4.2.5-P1/common/upf.c
+--- dhcp-4.2.5-P1.orig/common/upf.c	2013-01-24 02:04:59.000000000 +0900
++++ dhcp-4.2.5-P1/common/upf.c	2013-10-16 15:34:32.630194083 +0900
+@@ -320,7 +320,7 @@
+ 
+ 	/* Decode the IP and UDP headers... */
+ 	offset = decode_udp_ip_header (interface, ibuf, bufix,
+-				       from, length, &paylen);
++				       from, length, &paylen, 0);
+ 
+ 	/* If the IP or UDP checksum was bad, skip the packet... */
+ 	if (offset < 0)
+diff -uNr dhcp-4.2.5-P1.orig/includes/dhcpd.h dhcp-4.2.5-P1/includes/dhcpd.h
+--- dhcp-4.2.5-P1.orig/includes/dhcpd.h	2013-03-06 03:26:51.000000000 +0900
++++ dhcp-4.2.5-P1/includes/dhcpd.h	2013-10-16 15:34:32.626860658 +0900
+@@ -2810,7 +2810,7 @@
+ 			  unsigned, struct hardware *);
+ ssize_t decode_udp_ip_header (struct interface_info *, unsigned char *,
+ 			      unsigned, struct sockaddr_in *,
+-			      unsigned, unsigned *);
++			      unsigned, unsigned *, int);
+ 
+ /* ethernet.c */
+ void assemble_ethernet_header (struct interface_info *, unsigned char *,


### PR DESCRIPTION
VM上でdhclientを使用するとchecksumのエラーでアドレスが取得できない問題を修正するパッチを適用．
- http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=652739
- https://bugs.launchpad.net/ubuntu/+source/isc-dhcp/+bug/930962
