### PR TITLE
plamo/02_x11/TTfont.txz/freetype: 2.5.3 への更新

### DIFF
--- a/plamo/02_x11/TTfont.txz/freetype/PlamoBuild.freetype-2.5.3
+++ b/plamo/02_x11/TTfont.txz/freetype/PlamoBuild.freetype-2.5.3
@@ -1,12 +1,12 @@
 #!/bin/sh
 ##############################################################
-url='http://downloads.sourceforge.net/freetype/freetype-2.5.2.tar.bz2'
+url='http://downloads.sourceforge.net/freetype/freetype-2.5.3.tar.bz2'
 verify=$url.sig
 pkgbase=freetype
-vers=2.5.2
+vers=2.5.3
 arch=`uname -m | sed -e 's/i.86/i586/'`
 build=P1
-src=freetype-2.5.2
+src=${pkgbase}-${vers}
 OPT_CONFIG='--disable-static'
 DOCS='ChangeLog ChangeLog.20 ChangeLog.21 ChangeLog.22 ChangeLog.23 README README.git'
 patchfiles='freetype-2.2.1-enable-valid.patch'

--- a/plamo/02_x11/TTfont.txz/freetype/freetype-2.5.3-enable-spr.patch
+++ b/plamo/02_x11/TTfont.txz/freetype/freetype-2.5.3-enable-spr.patch
@@ -1,5 +1,6 @@
---- freetype-2.3.0/include/freetype/config/ftoption.h.spf	2007-01-18 14:27:34.000000000 -0500
-+++ freetype-2.3.0/include/freetype/config/ftoption.h	2007-01-18 14:27:48.000000000 -0500
+diff -uNr freetype-2.5.3.orig/include/config/ftoption.h freetype-2.5.3/include/config/ftoption.h
+--- freetype-2.5.3.orig/include/config/ftoption.h	2014-03-13 15:14:38.327949448 +0900
++++ freetype-2.5.3/include/config/ftoption.h	2014-03-13 15:18:07.933405782 +0900
 @@ -92,7 +92,7 @@
    /* This is done to allow FreeType clients to run unmodified, forcing     */
    /* them to display normal gray-level anti-aliased glyphs.                */

--- a/plamo/02_x11/TTfont.txz/freetype/freetype-2.5.3-enable-valid.patch
+++ b/plamo/02_x11/TTfont.txz/freetype/freetype-2.5.3-enable-valid.patch
@@ -1,5 +1,6 @@
---- freetype-2.2.1/modules.cfg.orig	2006-07-07 21:01:09.000000000 -0400
-+++ freetype-2.2.1/modules.cfg	2006-07-07 21:01:54.000000000 -0400
+diff -uNr freetype-2.5.3.orig/modules.cfg freetype-2.5.3/modules.cfg
+--- freetype-2.5.3.orig/modules.cfg	2014-03-13 15:14:38.324616309 +0900
++++ freetype-2.5.3/modules.cfg	2014-03-13 15:15:42.057285153 +0900
 @@ -110,7 +110,7 @@
  AUX_MODULES += cache
  
@@ -9,7 +10,7 @@
  
  # Support for streams compressed with gzip (files with suffix .gz).
  #
-@@ -124,7 +124,7 @@
+@@ -129,7 +129,7 @@
  
  # OpenType table validation.  Needs ftotval.c below.
  #


### PR DESCRIPTION
パッチも 2.5.3 用に作成しなおし
