### PR TITLE
plamo/01_minimum/curl: 7.40.0 への更新

### DIFF
--- a/plamo/01_minimum/network.txz/curl/PlamoBuild.curl-7.40.0
+++ b/plamo/01_minimum/network.txz/curl/PlamoBuild.curl-7.40.0
@@ -1,10 +1,10 @@
 #!/bin/sh
 ##############################################################
 pkgbase=curl
-vers=7.39.0
-url="http://curl.haxx.se/download/curl-7.39.0.tar.bz2"
+vers=7.40.0
+url="http://curl.haxx.se/download/curl-${vers}.tar.bz2"
 verify=$url.asc
-arch=`uname -m | sed -e 's/i.86/i586/'`
+arch=`uname -m`
 build=P1
 src=${pkgbase}-${vers}
 OPT_CONFIG='--with-gssapi --with-gssapi-includes=/usr/heimdal/include  --without-librtmp --disable-rtsp --disable-ldap --disable-ldaps --with-ca-bundle=/etc/ssl/certs/ca-bundle.crt'
@@ -14,7 +14,9 @@ else
     OPT_CONFIG=$OPT_CONFIG" --with-gssapi-libs=/usr/heimdal/lib"
 fi
 DOCS='COPYING README RELEASE-NOTES'
-patchfiles=''
+# the following patch only need 7.40.0, on upstream this has already fixed.
+# http://sourceforge.net/p/curl/bugs/1469/
+patchfiles='patch-lib_curl__sasl__gssapi.c'
 compress=txz
 ##############################################################
 

--- a/plamo/01_minimum/network.txz/curl/patch-lib_curl__sasl__gssapi.c
+++ b/plamo/01_minimum/network.txz/curl/patch-lib_curl__sasl__gssapi.c
@@ -1,0 +1,15 @@
+$NetBSD: patch-lib_curl__sasl__gssapi.c,v 1.1 2015/01/08 19:23:53 wiz Exp $
+
+Fix build on NetBSD with gssapi.
+
+--- a/lib/curl_sasl_gssapi.c.orig	2015-01-07 21:53:57.000000000 +0000
++++ b/lib/curl_sasl_gssapi.c
+@@ -126,7 +126,7 @@ CURLcode Curl_sasl_create_gssapi_user_me
+ 
+     /* Import the SPN */
+     gss_major_status = gss_import_name(&gss_minor_status, &spn_token,
+-                                       gss_nt_service_name, &krb5->spn);
++                                       GSS_C_NT_HOSTBASED_SERVICE, &krb5->spn);
+     if(GSS_ERROR(gss_major_status)) {
+       Curl_gss_log_error(data, gss_minor_status, "gss_import_name() failed: ");
+ 


### PR DESCRIPTION
* arch は uname -m で決定
* curl_sasl_gssapi.c でのコンパイルエラーに対応するパッチを適用