### PR TITLE
plamo/01_minimum/gnupg_tls.txz/libtasn1: 2.14への更新と脆弱性対応

### DIFF
--- a/plamo/01_minimum/gnupg_tls.txz/libtasn1/CVE-2014-3467.patch
+++ b/plamo/01_minimum/gnupg_tls.txz/libtasn1/CVE-2014-3467.patch
@@ -1,0 +1,52 @@
+CVE-2014-3467 (the DECR_LEN changes were omitted, since too intrusive
+               to backport for little impact) 
+
+Author: Nikos Mavrogiannopoulos <nmav@gnutls.org> 
+
+Upstream commits:
+ff3b5c68cc32e30d19edbbc3a962b2266029f3cc
+0e80d79db71747644394fe3472dad28cd3e7b00b
+51612fca32dda445056ca9a7533bae258acd3ecb
+ 
+--- libtasn1-3-2.13.orig/lib/decoding.c
++++ libtasn1-3-2.13/lib/decoding.c
+@@ -149,7 +149,7 @@ asn1_get_tag_der (const unsigned char *d
+       /* Long form */
+       punt = 1;
+       ris = 0;
+-      while (punt <= der_len && der[punt] & 128)
++      while (punt < der_len && der[punt] & 128)
+ 	{
+ 	  last = ris;
+ 
+@@ -258,9 +258,11 @@ _asn1_get_time_der (const unsigned char
+ 
+   if (der_len <= 0 || str == NULL)
+     return ASN1_DER_ERROR;
++
+   str_len = asn1_get_length_der (der, der_len, &len_len);
+-  if (str_len < 0 || str_size < str_len)
++  if (str_len <= 0 || str_size < str_len)
+     return ASN1_DER_ERROR;
++
+   memcpy (str, der + len_len, str_len);
+   str[str_len] = 0;
+   *ret_len = str_len + len_len;
+@@ -285,7 +287,7 @@ _asn1_get_objectid_der (const unsigned c
+     return ASN1_GENERIC_ERROR;
+   len = asn1_get_length_der (der, der_len, &len_len);
+ 
+-  if (len < 0 || len > der_len || len_len > der_len)
++  if (len <= 0 || len + len_len > der_len)
+     return ASN1_DER_ERROR;
+ 
+   val1 = der[len_len] / 40;
+@@ -762,7 +764,7 @@ _asn1_get_indefinite_length_string (cons
+ 
+   while (1)
+     {
+-      if ((*len) < counter)
++      if (counter+1 >= *len)
+ 	return ASN1_DER_ERROR;
+ 
+       if ((der[counter] == 0) && (der[counter + 1] == 0))

--- a/plamo/01_minimum/gnupg_tls.txz/libtasn1/CVE-2014-3468.patch
+++ b/plamo/01_minimum/gnupg_tls.txz/libtasn1/CVE-2014-3468.patch
@@ -1,0 +1,38 @@
+CVE-2014-3468
+
+Author: Nikos Mavrogiannopoulos <nmav@gnutls.org>
+
+Upstream commits:
+1c3ccb3e040bf13e342ee60bc23b21b97b11923f
+f245088c5bd6c7e9bea18e5601ee24d431531558
+
+--- libtasn1-3-2.13.orig/lib/decoding.c
++++ libtasn1-3-2.13/lib/decoding.c
+@@ -226,7 +226,7 @@ asn1_get_octet_der (const unsigned char
+ 		    int *ret_len, unsigned char *str, int str_size,
+ 		    int *str_len)
+ {
+-  int len_len;
++  int len_len = 0;
+ 
+   if (der_len <= 0)
+     return ASN1_GENERIC_ERROR;
+@@ -349,7 +349,7 @@ asn1_get_bit_der (const unsigned char *d
+ 		  int *ret_len, unsigned char *str, int str_size,
+ 		  int *bit_len)
+ {
+-  int len_len, len_byte;
++  int len_len = 0, len_byte;
+ 
+   if (der_len <= 0)
+     return ASN1_GENERIC_ERROR;
+@@ -359,6 +359,9 @@ asn1_get_bit_der (const unsigned char *d
+ 
+   *ret_len = len_byte + len_len + 1;
+   *bit_len = len_byte * 8 - der[len_len];
++  
++  if (*bit_len < 0)
++    return ASN1_DER_ERROR;
+ 
+   if (str_size >= len_byte)
+     memcpy (str, der + len_len + 1, len_byte);

--- a/plamo/01_minimum/gnupg_tls.txz/libtasn1/CVE-2014-3469.patch
+++ b/plamo/01_minimum/gnupg_tls.txz/libtasn1/CVE-2014-3469.patch
@@ -1,0 +1,84 @@
+CVE-2014-3469
+
+From: Nikos Mavrogiannopoulos <nmav@redhat.com>
+
+Upstream commits:
+a8b3e14f84174e01755bfd1be5448fffce7c9ffa
+3d6a02f19ff15a38dae9686033e37499b3968256
+53958290ab731c8486531a3bdef54a933533579d
+
+--- libtasn1-3-2.13.orig/lib/element.c
++++ libtasn1-3-2.13/lib/element.c
+@@ -112,8 +112,11 @@ _asn1_convert_integer (const unsigned ch
+     /* VALUE_OUT is too short to contain the value conversion */
+     return ASN1_MEM_ERROR;
+ 
+-  for (k2 = k; k2 < SIZEOF_UNSIGNED_LONG_INT; k2++)
+-    value_out[k2 - k] = val[k2];
++  if (value_out != NULL)
++    {
++      for (k2 = k; k2 < SIZEOF_UNSIGNED_LONG_INT; k2++)
++        value_out[k2 - k] = val[k2];
++    }
+ 
+ #if 0
+   printf ("_asn1_convert_integer: valueIn=%s, lenOut=%d", value, *len);
+@@ -617,7 +620,8 @@ asn1_write_value (ASN1_TYPE node_root, c
+ 	if (ptr_size < data_size) { \
+ 		return ASN1_MEM_ERROR; \
+ 	} else { \
+-		memcpy( ptr, data, data_size); \
++		if (ptr && data_size > 0) \
++	 	  memcpy( ptr, data, data_size); \
+ 	}
+ 
+ #define PUT_STR_VALUE( ptr, ptr_size, data) \
+@@ -626,17 +630,20 @@ asn1_write_value (ASN1_TYPE node_root, c
+ 		return ASN1_MEM_ERROR; \
+ 	} else { \
+ 		/* this strcpy is checked */ \
+-		_asn1_strcpy(ptr, data); \
++		if (ptr) { \
++		  _asn1_strcpy(ptr, data); \
++		} \
+ 	}
+ 
+ #define ADD_STR_VALUE( ptr, ptr_size, data) \
+-	*len = (int) _asn1_strlen(data) + 1; \
+-	if (ptr_size < (int) _asn1_strlen(ptr)+(*len)) { \
+-		return ASN1_MEM_ERROR; \
+-	} else { \
+-		/* this strcat is checked */ \
+-		_asn1_strcat(ptr, data); \
+-	}
++        *len += _asn1_strlen(data); \
++        if (ptr_size < (int) *len) { \
++                (*len)++; \
++                return ASN1_MEM_ERROR; \
++        } else { \
++                /* this strcat is checked */ \
++                if (ptr) _asn1_strcat (ptr, data); \
++        }
+ 
+ /**
+  * asn1_read_value:
+@@ -792,7 +799,9 @@ asn1_read_value (ASN1_TYPE root, const c
+     case TYPE_OBJECT_ID:
+       if (node->type & CONST_ASSIGN)
+ 	{
+-	  value[0] = 0;
++	  *len = 0;
++	  if (value)
++	  	value[0] = 0;
+ 	  p = node->down;
+ 	  while (p)
+ 	    {
+@@ -806,7 +815,7 @@ asn1_read_value (ASN1_TYPE root, const c
+ 		}
+ 	      p = p->right;
+ 	    }
+-	  *len = _asn1_strlen (value) + 1;
++	  (*len)++;
+ 	}
+       else if ((node->type & CONST_DEFAULT) && (node->value == NULL))
+ 	{

--- a/plamo/01_minimum/gnupg_tls.txz/libtasn1/CVE-2015-2806.patch
+++ b/plamo/01_minimum/gnupg_tls.txz/libtasn1/CVE-2015-2806.patch
@@ -1,0 +1,101 @@
+Description: CVE-2015-2806: stack overflow in asn1_der_decoding
+Origin: backport, http://git.savannah.gnu.org/gitweb/?p=libtasn1.git;a=commit;h=e47b2a0651ffe1867c844968ade7f6127957bf13,
+ http://git.savannah.gnu.org/gitweb/?p=libtasn1.git;a=commit;h=4d4f992826a4962790ecd0cce6fbba4a415ce149
+Bug-SuSE: https://bugzilla.novell.com/show_bug.cgi?id=924828
+Bug-RedHat: https://bugzilla.redhat.com/show_bug.cgi?id=1207192
+Forwarded: not-needed
+Author: Salvatore Bonaccorso <carnil@debian.org>
+Last-Update: 2015-04-11
+Applied-Upstream: 4.4
+
+--- a/lib/coding.c
++++ b/lib/coding.c
+@@ -34,6 +34,11 @@
+ 
+ #define MAX_TAG_LEN 16
+ 
++/* MAX(a,b) returns the maximum of A and B.  */
++#ifndef MAX
++# define MAX(a,b) ((a) > (b) ? (a) : (b))
++#endif
++
+ /******************************************************/
+ /* Function : _asn1_error_description_value_not_found */
+ /* Description: creates the ErrorDescription string   */
+@@ -451,7 +456,7 @@ _asn1_insert_tag_der (ASN1_TYPE node, un
+ {
+   ASN1_TYPE p;
+   int tag_len, is_tag_implicit;
+-  unsigned char class, class_implicit = 0, temp[SIZEOF_UNSIGNED_INT * 3 + 1];
++  unsigned char class, class_implicit = 0, temp[MAX(SIZEOF_UNSIGNED_INT * 3 + 1, LTOSTR_MAX_SIZE)];
+   unsigned long tag_implicit = 0;
+   unsigned char tag_der[MAX_TAG_LEN];
+ 
+@@ -871,7 +876,7 @@ asn1_der_coding (ASN1_TYPE element, cons
+ 		 char *ErrorDescription)
+ {
+   ASN1_TYPE node, p, p2;
+-  unsigned char temp[SIZEOF_UNSIGNED_LONG_INT * 3 + 1];
++  unsigned char temp[MAX(LTOSTR_MAX_SIZE, SIZEOF_UNSIGNED_LONG_INT * 3 + 1)];
+   int counter, counter_old, len2, len3, tlen, move, max_len, max_len_old;
+   asn1_retCode err;
+   unsigned char *der = ider;
+--- a/lib/parser_aux.c
++++ b/lib/parser_aux.c
+@@ -579,10 +579,10 @@ _asn1_delete_list_and_nodes (void)
+ 
+ 
+ char *
+-_asn1_ltostr (long v, char *str)
++_asn1_ltostr (long v, char str[LTOSTR_MAX_SIZE])
+ {
+   long d, r;
+-  char temp[20];
++  char temp[LTOSTR_MAX_SIZE];
+   int count, k, start;
+ 
+   if (v < 0)
+@@ -603,7 +603,7 @@ _asn1_ltostr (long v, char *str)
+       count++;
+       v = d;
+     }
+-  while (v);
++  while (v && ((start+count) < LTOSTR_MAX_SIZE-1));
+ 
+   for (k = 0; k < count; k++)
+     str[k + start] = temp[start + count - k - 1];
+--- a/lib/parser_aux.h
++++ b/lib/parser_aux.h
+@@ -62,7 +62,9 @@ void _asn1_delete_list (void);
+ 
+ void _asn1_delete_list_and_nodes (void);
+ 
+-char *_asn1_ltostr (long v, char *str);
++/* Max 64-bit integer length is 20 chars + 1 for sign + 1 for null termination */
++#define LTOSTR_MAX_SIZE 22
++char *_asn1_ltostr (long v, char str[LTOSTR_MAX_SIZE]);
+ 
+ ASN1_TYPE _asn1_find_up (ASN1_TYPE node);
+ 
+--- a/lib/decoding.c
++++ b/lib/decoding.c
+@@ -276,7 +276,7 @@ _asn1_get_objectid_der (const unsigned c
+ {
+   int len_len, len, k;
+   int leading;
+-  char temp[20];
++  char temp[LTOSTR_MAX_SIZE];
+   unsigned long val, val1, prev_val;
+ 
+   *ret_len = 0;
+--- a/lib/element.c
++++ b/lib/element.c
+@@ -133,7 +133,7 @@ int
+ _asn1_append_sequence_set (ASN1_TYPE node)
+ {
+   ASN1_TYPE p, p2;
+-  char temp[10];
++  char temp[LTOSTR_MAX_SIZE];
+   long n;
+ 
+   if (!node || !(node->down))

--- a/plamo/01_minimum/gnupg_tls.txz/libtasn1/PlamoBuild.libtasn1-2.14
+++ b/plamo/01_minimum/gnupg_tls.txz/libtasn1/PlamoBuild.libtasn1-2.14
@@ -1,15 +1,15 @@
 #!/bin/sh
 ##############################################################
-url='http://ftp.gnu.org/gnu/libtasn1/libtasn1-2.12.tar.gz'
+vers=2.14
+arch=`uname -m`
+url="http://ftp.gnu.org/gnu/libtasn1/libtasn1-${vers}.tar.gz"
+verify=$url.sig
 pkgbase=libtasn1
-vers=2.12
-arch=x86_64
-# arch=i586
 build=P1
-src=libtasn1-2.12
+src=libtasn1-${vers}
 OPT_CONFIG='--disable-static'
 DOCS='.clcopying AUTHORS COPYING COPYING.LIB ChangeLog INSTALL NEWS README THANKS'
-patchfiles=''
+patchfiles='CVE-2014-3467.patch CVE-2014-3468.patch CVE-2014-3469.patch CVE-2015-2806.patch'
 compress=txz
 ##############################################################
 
@@ -136,6 +136,20 @@ convert() {
   for i in `seq 9` n ; do prune_symlink $mandir/man$i ; done
 }
 
+verify_checksum() {
+  echo "Verify Checksum..."
+  checksum_command=$1
+  verify_file=${verify##*/}
+  for s in $url ; do
+    srcsum=`$checksum_command ${s##*/}`
+    verifysum=`grep ${s##*/} $verify_file`
+    if [ x"$srcsum" != x"$verifysum" ]; then
+      return 1
+    fi
+  done
+  return 0
+}
+
 W=`pwd`
 for i in `seq 0 $((${#src[@]} - 1))` ; do
   S[$i]=$W/${src[$i]} 
@@ -177,6 +191,24 @@ fi
 if [ $opt_download -eq 1 ] ; then
   for i in $url ; do
     if [ ! -f ${i##*/} ] ; then wget $i ; fi
+  done
+  for i in $verify ; do
+    if [ ! -f ${i##*/} ] ; then
+      wget $i
+    fi
+  done
+  for i in $verify ; do
+    case ${i##*.} in
+    asc) gpg2 --verify ${i##*/} ;;
+    sig) gpg2 --verify ${i##*/} ;;
+    sha256sum) verify_checksum "sha256sum" ;;
+    esac
+    if [ $? -ne 0 ]; then
+      echo "archive verify was failed."
+      exit 1
+    else
+      echo "archive verify was successed."
+    fi
   done
   for i in $url ; do
     case ${i##*.} in


### PR DESCRIPTION
* CVE-2014-3467
* CVE-2014-3468
* CVE-2014-3469
* CVE-2015-2806
* 署名確認
* arch検出