### PR TITLE
plamo/05_ext/network2.txz/php: システムのlibzipを使用するようにした

### DIFF
--- a/plamo/05_ext/network2.txz/php/PlamoBuild.php-5.6.11
+++ b/plamo/05_ext/network2.txz/php/PlamoBuild.php-5.6.11
@@ -7,7 +7,7 @@ arch=`uname -m`
 build=P1
 src=${pkgbase}-${vers}
 CONFDIR="/etc/httpd/"
-OPT_CONFIG="--with-apxs2=/usr/bin/apxs --with-zlib --with-curl --with-gd --enable-gd-jis-conv --with-freetype-dir=/usr --with-jpeg-dir=/usr --enable-mbstring --enable-pdo --with-pdo-mysql=shared,/opt/mysql --with-pdo-sqlite --with-config-file-path=$CONFDIR --enable-zip=shared --enable-ftp=shared --with-bz2=shared --with-db4=shared,/usr --with-gdbm=shared --enable-exif=shared --with-ldap=shared"
+OPT_CONFIG="--with-apxs2=/usr/bin/apxs --with-zlib --with-curl --with-gd --enable-gd-jis-conv --with-freetype-dir=/usr --with-jpeg-dir=/usr --enable-mbstring --enable-pdo --with-pdo-mysql=shared,/opt/mysql --with-pdo-sqlite --with-config-file-path=$CONFDIR --enable-zip=shared --with-libzip --enable-ftp=shared --with-bz2=shared --with-db4=shared,/usr --with-gdbm=shared --enable-exif=shared --with-ldap=shared"
 if [ $arch == 'x86_64' ]; then
   OPT_CONFIG="$OPT_CONFIG --with-libdir=lib64"
 fi


### PR DESCRIPTION
* configure オプションに --with-libzip を追加
* この設定でパッケージをリリースするのは次のバージョンとする