### PR TITLE
plamo/01_minimum/network.txz/bind: 9.9.8 への更新

### DIFF
--- a/plamo/01_minimum/network.txz/bind/PlamoBuild.bind-9.9.8
+++ b/plamo/01_minimum/network.txz/bind/PlamoBuild.bind-9.9.8
@@ -1,7 +1,7 @@
 #!/bin/sh
 ##############################################################
 pkgbase=bind
-vers=9.9.7_P3
+vers=9.9.8
 url="ftp://ftp.isc.org/isc/bind/${vers/_/-}/bind-${vers/_/-}.tar.gz"
 verify=$url.asc
 arch=`uname -m`


### PR DESCRIPTION
ルートヒントファイルの更新含む