### PR TITLE
plamo/01_minimum/network.txz/curl: 7.49.1 への更新

### DIFF
--- a/plamo/01_minimum/network.txz/curl/PlamoBuild.curl-7.49.1
+++ b/plamo/01_minimum/network.txz/curl/PlamoBuild.curl-7.49.1
@@ -1,13 +1,13 @@
 #!/bin/sh
 ##############################################################
 pkgbase=curl
-vers=7.47.0
+vers=7.49.1
 url="http://curl.haxx.se/download/curl-${vers}.tar.bz2"
 verify=$url.asc
 arch=`uname -m`
 build=P1
 src=${pkgbase}-${vers}
-OPT_CONFIG='--with-gssapi --with-gssapi-includes=/usr/heimdal/include  --without-librtmp --disable-rtsp --disable-ldap --disable-ldaps --with-ca-bundle=/etc/ssl/certs/ca-bundle.crt'
+OPT_CONFIG='--with-gssapi --with-gssapi-includes=/usr/heimdal/include  --without-librtmp --disable-rtsp --disable-ldap --disable-ldaps --with-ca-bundle=/etc/ssl/certs/ca-bundle.crt --without-nghttp2'
 if [ "$arch" = "x86_64" ]; then
     OPT_CONFIG=$OPT_CONFIG" --with-gssapi-libs=/usr/heimdal/lib64"
 else


### PR DESCRIPTION
--without-nghttp2 を付与 (05_ext 以下なので)