### PR TITLE
[RFC] plamo/00_base/sysvinit: rc.6スクリプトの更新

### DIFF
--- a/plamo/00_base/sysvinit/etc/rc.d/rc.6
+++ b/plamo/00_base/sysvinit/etc/rc.d/rc.6
@@ -108,10 +108,13 @@ if [ -x /sbin/hwclock ] ; then
 fi
 
 # Unmount any remote filesystems.
-if [ -n "`mount -anfv -t nfs 2> /dev/null`" ] ; then
-  echo "Unmounting remote filesystems..."
-  umount -a -t nfs
-fi
+for type in `cat /proc/self/mounts | awk '{ print $3 }'`
+do
+  if [ x$type = "xnfs" ]; then
+    echo "Unmounting remote NFS filesystems..."
+    umount -a -t nfs
+  fi
+done
 
 # Turn off swap, then unmount local file systems.
 echo "Turning off swap..."


### PR DESCRIPTION
NFSマウントされていた場合にumountするコードがあるが、mount -vの出力の有無を見ており、今のmountコマンドだとNFSマウントの有無に関わらず状態表示がされるため、NFSマウントされていなくてもumountが実行されるため