### PR TITLE
複数ソース処理、不要な処理の除去と git 対応

### DIFF
--- a/admin/make_PlamoBuild.py
+++ b/admin/make_PlamoBuild.py
@@ -190,11 +190,11 @@ if [ $opt_config -eq 1 ] ; then
             touch .${{patch}}
         fi
     done
-
-    cd $B
-    # if [ -f $S/autogen.sh ] ; then
+    # if [ -f autogen.sh ] ; then
     #   sh ./autogen.sh
     # fi
+
+    cd $B
     export PKG_CONFIG_PATH=/usr/${{libdir}}/pkgconfig:/usr/share/pkgconfig:/opt/kde/${{libdir}}/pkgconfig
     export LDFLAGS='-Wl,--as-needed' 
     $S/configure --prefix={0} --sysconfdir=/etc --localstatedir=/var --mandir='${{prefix}}'/share/man ${{OPT_CONFIG[$i]}}

--- a/admin/plamobuild_functions.sh
+++ b/admin/plamobuild_functions.sh
@@ -129,10 +129,9 @@ download_sources() {
     fi
     ;;
   esac
-  case ${url##*.} in
-  tar) tar xvpf ${url##*/} ;;
-  gz) tar xvpzf ${url##*/} ;;
-  bz2) tar xvpjf ${url##*/} ;;
+  case ${url##*/} in
+  *.tar*) tar xvf ${url##*/} ;;
+  *.zip) unzip ${url##*/} ;;
   git)
     ( cd $(basename ${url##*/} .git)
       git checkout master
@@ -140,7 +139,6 @@ download_sources() {
         git checkout -b build $commitid
       fi
     ) ;;
-  *) tar xvf ${url##*/} ;;
   esac
 }
 

--- a/admin/plamobuild_functions.sh
+++ b/admin/plamobuild_functions.sh
@@ -106,9 +106,9 @@ download_sources() {
       j=${url%.*}
       for sig in asc sig{,n} {sha{256,1},md5}{,sum} ; do
         if wget --spider $url.$sig ; then
-	  wget $url.$sig
-	  break
-	fi
+          wget $url.$sig
+          break
+        fi
         if wget --spider $j.$sig ; then
           case ${url##*.} in
           gz) gunzip -c ${url##*/} > ${j##*/} ;;
@@ -137,7 +137,7 @@ download_sources() {
     ( cd $(basename ${url##*/} .git)
       git checkout master
       if [ -n "$commitid" ]; then
-	git checkout -b build $commitid
+        git checkout -b build $commitid
       fi
     ) ;;
   *) tar xvf ${url##*/} ;;
@@ -199,22 +199,13 @@ install_tweak() {
 
   # doc ファイルのインストールと圧縮  
   cd $W
-  for i in `seq 0 $((${#DOCS[@]} - 1))` ; do
-    for j in ${DOCS[$i]} ; do
-      for k in ${S[$i]}/$j ; do
-        install2 $k $docdir/${src[$i]}/${k#${S[$i]}/}
-        touch -r $k $docdir/${src[$i]}/${k#${S[$i]}/}
-        gzip_one $docdir/${src[$i]}/${k#${S[$i]}/}
-      done
-    done
-    if [ $i -eq 0 ] ; then
-      install $myname $docdir/$src
-      gzip_one $docdir/$src/$myname
-    else
-      ln $docdir/$src/$myname.gz $docdir/${src[$i]}
-    fi
-    ( cd $docdir ; find ${src[$i]} -type d -exec touch -r $W/{} {} \; )
+  for doc in $DOCS ; do
+    install2 $S/$doc $docdir/$src/$doc
+    touch -r $S/$doc $docdir/$src/$doc
+    gzip_one $docdir/$src/$doc
   done
+  install $myname $docdir/$src
+  gzip_one $docdir/$src/$myname
 
   # パッチファイルのインストール  
   for patch in $patchfiles ; do
@@ -235,14 +226,13 @@ install_tweak() {
 
 W=`pwd`
 WD=/tmp
-for i in `seq 0 $((${#src[@]} - 1))` ; do
-  S[$i]=$W/${src[$i]} 
-  if [ $arch = "x86_64" ]; then
-    B[$i]=$WD/build`test ${#src[@]} -eq 1 || echo $i`
-  else
-    B[$i]=$WD/build32`test ${#src[@]} -eq 1 || echo $i`
-  fi
-done
+S=$W/$src
+if [ $arch = "x86_64" ]; then
+  B=$WD/build
+else
+  B=$WD/build32
+fi
+
 P=$W/work ; C=$W/pivot
 infodir=$P/usr/share/info
 mandir=$P/usr/share/man

--- a/admin/plamobuild_functions.sh
+++ b/admin/plamobuild_functions.sh
@@ -225,13 +225,10 @@ install_tweak() {
 W=`pwd`
 WD=/tmp
 S=$W/$src
-if [ $arch = "x86_64" ]; then
-  B=$WD/build
-else
-  B=$WD/build32
-fi
+B=$WD/build
+P=$W/work
+C=$W/pivot
 
-P=$W/work ; C=$W/pivot
 infodir=$P/usr/share/info
 mandir=$P/usr/share/man
 xmandir=$P/usr/X11R7/share/man

--- a/admin/plamobuild_functions.sh
+++ b/admin/plamobuild_functions.sh
@@ -92,38 +92,40 @@ gzip_one() {
 
 
 download_sources() {
-  for i in $url ; do
-    if [ ! -f ${i##*/} ] ; then
-      wget $i ; j=${i%.*}
-      for sig in asc sig{,n} {sha{256,1},md5}{,sum} ; do
-        if wget --spider $i.$sig ; then wget $i.$sig ; break ; fi
-        if wget --spider $j.$sig ; then
-          case ${i##*.} in
-          gz) gunzip -c ${i##*/} > ${j##*/} ;;
-          bz2) bunzip2 -c ${i##*/} > ${j##*/} ;;
-          xz) unxz -c ${i##*/} > ${j##*/} ;;
-          esac
-          touch -r ${i##*/} ${j##*/} ; i=$j ; wget $i.$sig ; break
-        fi
-      done
-      if [ -f ${i##*/}.$sig ] ; then
-        case $sig in
-        asc|sig|sign) gpg2 --verify ${i##*/}.$sig ;;
-        sha256|sha1|md5) ${sig}sum -c ${i##*/}.$sig ;;
-        *) $sig -c ${i##*/}.$sig ;;
-        esac
-        if [ $? -ne 0 ] ; then echo "archive verify failed" ; exit ; fi
+  if [ ! -f ${url##*/} ] ; then
+    wget $url
+    j=${url%.*}
+    for sig in asc sig{,n} {sha{256,1},md5}{,sum} ; do
+      if wget --spider $url.$sig ; then
+        wget $url.$sig
+        break
       fi
+      if wget --spider $j.$sig ; then
+        case ${url##*.} in
+          gz) gunzip -c ${url##*/} > ${j##*/} ;;
+          bz2) bunzip2 -c ${url##*/} > ${j##*/} ;;
+          xz) unxz -c ${url##*/} > ${j##*/} ;;
+        esac
+        touch -r ${url##*/} ${j##*/} ; url=$j ; wget $url.$sig ; break
+      fi
+    done
+    if [ -f ${url##*/}.$sig ] ; then
+      case $sig in
+        asc|sig|sign) gpg2 --verify ${url##*/}.$sig ;;
+        sha256|sha1|md5) ${sig}sum -c ${url##*/}.$sig ;;
+        *) $sig -c ${url##*/}.$sig ;;
+      esac
+      if [ $? -ne 0 ] ; then echo "archive verify failed" ; exit ; fi
     fi
-  done
-  for i in $url ; do
-    case ${i##*.} in
-      tar) tar xvpf ${i##*/} ;;
-      gz) tar xvpzf ${i##*/} ;;
-      bz2) tar xvpjf ${i##*/} ;;
-      *) tar xvf ${i##*/} ;;
-    esac
-  done
+  fi
+  ;;
+  esac
+  case ${url##*.} in
+    tar) tar xvpf ${url##*/} ;;
+    gz) tar xvpzf ${url##*/} ;;
+    bz2) tar xvpjf ${url##*/} ;;
+    *) tar xvf ${url##*/} ;;
+  esac
 }
 
 verify_checksum() {


### PR DESCRIPTION
* 一部、複数ソースを処理するコードが残っていたので除去
* ソースが git の場合の対応
* ソースアーカイブの展開時、圧縮形式は tar コマンドに任せるようにした
* ソースアーカイブが *.zip なら unzip コマンドで展開するようにした
* arch によってビルドディレクトリを分ける処理を廃止
* (なるべく処理をわかりやすくするようにしています)
* build out of tree の場合、autogen.sh をソースディレクトリで実行するように修正