### PR TITLE
admin/plamobuild_functions.sh: locale 以下の処理の不具合修正

### DIFF
--- a/admin/plamobuild_functions.sh
+++ b/admin/plamobuild_functions.sh
@@ -182,7 +182,7 @@ install_tweak() {
   fi
 
   # ja 以外のlocaleファイルを削除
-  for loc_dir in `find $P/usr/share -name locale` ; do
+  for loc_dir in `find -type d $P/usr/share -name locale` ; do
     pushd $loc_dir
     for loc in * ; do
       if [ "$loc" != "ja" ]; then


### PR DESCRIPTION
/usr/share 以下にディレクトリ以外の "locale" があった場合、make
install したファイルを消去してしまう可能性がある