### PR TITLE
admin: ソース確認用のハッシュ/署名ファイルのURLを指定できるようにした

### DIFF
--- a/admin/make_PlamoBuild.py
+++ b/admin/make_PlamoBuild.py
@@ -100,6 +100,7 @@ def make_headers(url, srcdir, pkgbase, vers, readme, patchfiles, method):
 pkgbase='{1}'
 vers='{2}'
 url="{0}"
+verify=""
 arch=`uname -m`
 build=P1
 src="{3}"
@@ -115,6 +116,7 @@ compress=txz
 pkgbase='{1}'
 vers='{2}'
 url="{0}"
+verify=""
 arch=`uname -m`
 build=P1
 src="{3}"


### PR DESCRIPTION
* "$verify"でハッシュ・署名ファイルのURLを指定できるようにした
* ハッシュ/署名ファイルの存在URLが明らかであるなら、指定したほうがwgetのspiderモードを使うよりダウンロード元のリソースを消費しない
* spiderモードは302でリダイレクトされる場合もエラーになるので存在しているファイルもエラーになり、ダウンロード元に余計な負荷をかける
* "$verify"が未定義or空文字列であれば今までどおりspiderモードを使う