### PR TITLE
contrib/Network/google_chrome: 60.0.311.7 への更新

### DIFF
--- a/contrib/Network/google_chrome/PlamoBuild.google-chrome-60.0.3112.78
+++ b/contrib/Network/google_chrome/PlamoBuild.google-chrome-60.0.3112.78
@@ -1,7 +1,7 @@
 #!/bin/sh
 ##############################################################
 pkgbase=google_chrome
-vers=59.0.3071.115
+vers=60.0.3112.785
 verbld=1
 arch=`uname -m | sed -e 's/i.86/i386/'`
 url="https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm"


### PR DESCRIPTION
スクリプトの更新のみでパッケージリリースはなし