### PR TITLE
git 2.17.0 B2

### DIFF
--- a/plamo/02_devel/git/PlamoBuild.git-2.17.0
+++ b/plamo/02_devel/git/PlamoBuild.git-2.17.0
@@ -8,7 +8,7 @@ man_url="https://www.kernel.org/pub/software/scm/git/git-manpages-${vers}.tar.xz
 arch=`uname -m`
 build=B2
 src="${pkgbase}-${vers}"
-OPT_CONFIG='--with-gitconfig=/etc/gitconfig --with-libpcre1 --without-tcltk --without-python'
+OPT_CONFIG='--with-gitconfig=/etc/gitconfig --without-tcltk --without-python'
 DOCS='COPYING INSTALL README.md command-list.txt'
 patchfiles=''
 compress=txz

--- a/plamo/02_devel/git/PlamoBuild.git-2.17.0
+++ b/plamo/02_devel/git/PlamoBuild.git-2.17.0
@@ -6,9 +6,9 @@ url="https://www.kernel.org/pub/software/scm/${pkgbase}/${pkgbase}-${vers}.tar.x
 verify="https://www.kernel.org/pub/software/scm/${pkgbase}/${pkgbase}-${vers}.tar.sign"
 man_url="https://www.kernel.org/pub/software/scm/git/git-manpages-${vers}.tar.xz"
 arch=`uname -m`
-build=B1
+build=B2
 src="${pkgbase}-${vers}"
-OPT_CONFIG='--with-gitconfig=/etc/gitconfig --with-libpcre2 --without-tcltk --without-python'
+OPT_CONFIG='--with-gitconfig=/etc/gitconfig --with-libpcre1 --without-tcltk --without-python'
 DOCS='COPYING INSTALL README.md command-list.txt'
 patchfiles=''
 compress=txz


### PR DESCRIPTION
* --with-libpcre2 削除
* --with-libpcre1 は Plamo の pcre が要件を満たさないようなのでいったん PCRE サポートを削除