### PR TITLE
plamo/00_base/pciutils: 3.6.2

### DIFF
--- a/plamo/00_base/pciutils/PlamoBuild.pciutils-3.6.2
+++ b/plamo/00_base/pciutils/PlamoBuild.pciutils-3.6.2
@@ -1,7 +1,7 @@
 #!/bin/sh
 ##############################################################
 pkgbase='pciutils'
-vers="3.5.6"
+vers="3.6.2"
 url="https://www.kernel.org/pub/software/utils/pciutils/pciutils-${vers}.tar.xz"
 verify="https://www.kernel.org/pub/software/utils/pciutils/pciutils-${vers}.tar.sign"
 arch=`uname -m`


### PR DESCRIPTION
3.5.6 パッケージは ZLIB=no を指定し忘れているので pic.ids が圧縮されて
しまっているので修正