### PR TITLE
plamo/01_minimum/sqlite: 3.25.2 B2

### DIFF
--- a/plamo/01_minimum/sqlite/PlamoBuild.sqlite-3.25.2
+++ b/plamo/01_minimum/sqlite/PlamoBuild.sqlite-3.25.2
@@ -7,14 +7,16 @@ url="http://sqlite.org/2018/sqlite-autoconf-3250200.tar.gz"
 digest="sha1sum:aedfbdc14eb700099434d6a743135743cff47393"
 verify=""
 arch=`uname -m`
-build=B1
+build=B2
 src="sqlite-autoconf-${srcver}"
 OPT_CONFIG='--disable-static --enable-fts5'
 DOCS='INSTALL README.txt'
 patchfiles=''
 compress=txz
 ##############################################################
-export CPPFLAGS="$CPPFLAGS -DSQLITE_ENABLE_FTS4=1 \
+export CPPFLAGS="$CPPFLAGS \
+       -DSQLITE_ENABLE_FTS3=1 \
+       -DSQLITE_ENABLE_FTS4=1 \
        -DSQLITE_ENABLE_COLUMN_METADATA=1 \
        -DSQLITE_ENABLE_UNLOCK_NOTIFY=1 \
        -DSQLITE_ENABLE_DBSTAT_VTAB=1 \


### PR DESCRIPTION
"SQLITE_ENABLE_FTS3=1" を追加。以前はなくても問題なかったが、いつから
か必要になった模様