### PR TITLE
plamo/02_devel/plamobuild: 1.3

### DIFF
--- a/plamo/02_devel/plamobuild/PlamoBuild.plamobuild-1.3
+++ b/plamo/02_devel/plamobuild/PlamoBuild.plamobuild-1.3
@@ -1,7 +1,7 @@
 #!/bin/sh
 ##############################################################
 pkgbase='plamobuild'
-vers='1.2'
+vers='1.3'
 url=("https://raw.githubusercontent.com/plamolinux/Plamo-src/plamo-7.x/admin/plamobuild_functions.sh"
      "https://raw.githubusercontent.com/plamolinux/Plamo-src/plamo-7.x/admin/make_PlamoBuild.py"
      "https://raw.githubusercontent.com/plamolinux/Plamo-src/plamo-7.x/admin/remove-la-files.sh")


### PR DESCRIPTION
make_PlamoBuild: -p オプションを python, perl でも有効になるようにした