### PR TITLE
plamo/05_ext/acpid: 2.0.31 B3

### DIFF
--- a/plamo/05_ext/acpid/PlamoBuild.acpid-2.0.31
+++ b/plamo/05_ext/acpid/PlamoBuild.acpid-2.0.31
@@ -6,7 +6,7 @@ url="https://downloads.sourceforge.net/acpid2/${pkgbase}-${vers}.tar.xz"
 digest="md5sum:599dd38681b5917eeeafb58176793952"
 verify=""
 arch=`uname -m`
-build=B2
+build=B3
 src="${pkgbase}-${vers}"
 OPT_CONFIG="--disable-static --enable-shared --docdir=/usr/share/doc/$src --runstatedir=/run"
 DOCS='COPYING Changelog README TODO'
@@ -85,11 +85,11 @@ if [ $opt_package -eq 1 ] ; then
 
   cp -r samples $docdir/$src/
 
-  install -v -m644 $W/lid $P/etc/acpi/events/lid
-  install -v -m755 $W/lid.sh $P/etc/acpi/lid.sh
+  install -v -m644 $W/allevents $P/etc/acpi/events/allevents
+  install -v -m755 $W/handler.sh $P/etc/acpi/handler.sh
 
-  install -v -Dm644 $W/lid $docdir/$src/lid
-  install -v -Dm644 $W/lid.sh $docdir/$src/lid.sh
+  install -v -Dm644 $W/allevents $docdir/$src/allevents
+  install -v -Dm644 $W/handler.sh $docdir/$src/handler.sh
 
   install -v -m755 -D $W/acpid.init $P/etc/rc.d/init.d/acpid
   for i in $(seq 0 6)

--- a/plamo/05_ext/acpid/allevents
+++ b/plamo/05_ext/acpid/allevents
@@ -1,0 +1,3 @@
+# Pass all events to our handler script
+event=.*
+action=/etc/acpi/handler.sh %e

--- a/plamo/05_ext/acpid/handler.sh
+++ b/plamo/05_ext/acpid/handler.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Default acpi script that takes an entry for all actions
+
+case "$1" in
+    button/power)
+        case "$2" in
+            PBTN|PWRF)
+                logger 'PowerButton pressed'
+                ;;
+            *)
+                logger "ACPI action undefined: $2"
+                ;;
+        esac
+        ;;
+    button/sleep)
+        case "$2" in
+            SLPB|SBTN)
+                logger 'SleepButton pressed'
+                ;;
+            *)
+                logger "ACPI action undefined: $2"
+                ;;
+        esac
+        ;;
+    ac_adapter)
+        case "$2" in
+            AC|ACAD|ADP0)
+                case "$4" in
+                    00000000)
+                        logger 'AC unpluged'
+                        ;;
+                    00000001)
+                        logger 'AC pluged'
+                        ;;
+                esac
+                ;;
+            *)
+                logger "ACPI action undefined: $2"
+                ;;
+        esac
+        ;;
+    battery)
+        case "$2" in
+            BAT0)
+                case "$4" in
+                    00000000)
+                        logger 'Battery online'
+                        ;;
+                    00000001)
+                        logger 'Battery offline'
+                        ;;
+                esac
+                ;;
+            CPU0)
+                ;;
+            *)  logger "ACPI action undefined: $2" ;;
+        esac
+        ;;
+    button/lid)
+        case "$3" in
+            close)
+                logger 'LID closed'
+                ;;
+            open)
+                logger 'LID opened'
+                ;;
+            *)
+                logger "ACPI action undefined: $3"
+                ;;
+    esac
+    ;;
+    *)
+        logger "ACPI group/action undefined: $1 / $2"
+        ;;
+esac
+
+# vim:set ts=4 sw=4 ft=sh et:

--- a/plamo/05_ext/acpid/lid
+++ b/plamo/05_ext/acpid/lid
@@ -1,2 +1,0 @@
-event=button/lid
-action=/etc/acpi/lid.sh

--- a/plamo/05_ext/acpid/lid.sh
+++ b/plamo/05_ext/acpid/lid.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-/bin/grep -q open /proc/acpi/button/lid/LID/state && exit 0
-/usr/sbin/pm-suspend


### PR DESCRIPTION
すべてのイベントを取得し、ハンドラースクリプトに渡すようにした。
デフォルトではログ出力のみを行うようにしてある。