### PR TITLE
plamo/05_ext/bluez: 5.51 B3

### DIFF
--- a/plamo/05_ext/bluez/PlamoBuild.bluez-5.51
+++ b/plamo/05_ext/bluez/PlamoBuild.bluez-5.51
@@ -1,16 +1,16 @@
 #!/bin/sh
 ##############################################################
 pkgbase='bluez'
-vers='5.50'
+vers='5.51'
 url="https://www.kernel.org/pub/linux/bluetooth/${pkgbase}-${vers}.tar.xz"
 verify="https://www.kernel.org/pub/linux/bluetooth/bluez-${vers}.tar.sign"
 arch=`uname -m`
-build=B1
+build=B3
 src="${pkgbase}-${vers}"
 OPT_CONFIG="--enable-library --disable-systemd"
 DOCS='AUTHORS COPYING COPYING.LIB ChangeLog INSTALL NEWS README TODO'
-blfs_patch="http://www.linuxfromscratch.org/patches/blfs/svn/bluez-5.50-obexd_without_systemd-1.patch"
-patchfiles="${blfs_patch##*/}"
+# from arch linux
+patchfiles="bluez-5.51-obexd_without_systemd-1.patch refresh_adv_manager_for_non-LE_devices.diff"
 compress=txz
 ##############################################################
 
@@ -56,17 +56,18 @@ if [ $opt_config -eq 1 ] ; then
   # if [ -f autogen.sh ] ; then
   #   sh ./autogen.sh
   # fi
+  autoreconf -ivf
 
   export PKG_CONFIG_PATH=/usr/${libdir}/pkgconfig:/usr/share/pkgconfig:/opt/kde/${libdir}/pkgconfig
   export LDFLAGS='-Wl,--as-needed' 
   ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var --mandir='${prefix}'/share/man ${OPT_CONFIG}
-    
+
   if [ $? != 0 ]; then
     echo "configure error. $0 script stop"
     exit 255
   fi
 fi
-    
+
 if [ $opt_build -eq 1 ] ; then
   cd $B
   export LDFLAGS='-Wl,--as-needed'
@@ -87,7 +88,10 @@ if [ $opt_package -eq 1 ] ; then
   install -dm755 -v $P/usr/sbin
   ln -svf ../libexec/bluetooth/bluetoothd $P/usr/sbin/bluetoothd
 
+  # conf
   install -Dm644 -v $S/src/main.conf $P/etc/bluetooth/main.conf
+  install -Dm644 -v $W/btusb.conf $P/etc/modprobe.d/btusb.conf
+  install -Dm644 -v $W/btusb.conf $docdir/$src/btusb.conf
 
   install -dm755 -v $docdir/$src
   install -m644  -v $S/doc/*.txt $docdir/$src/
@@ -100,11 +104,11 @@ if [ $opt_package -eq 1 ] ; then
     install -dm755 -v $P/etc/rc.d/rc"$i".d
     case $i in
       0|1|2|6)
-	ln -sfv ../init.d/bluetooth $P/etc/rc.d/rc"$i".d/K27bluetooth
-	;;
+        ln -sfv ../init.d/bluetooth $P/etc/rc.d/rc"$i".d/K27bluetooth
+        ;;
       3|4|5)
         ln -sfv ../init.d/bluetooth $P/etc/rc.d/rc"$i".d/S35bluetooth
-	;;
+        ;;
     esac
   done
 

--- a/plamo/05_ext/bluez/bluez-5.51-obexd_without_systemd-1.patch
+++ b/plamo/05_ext/bluez/bluez-5.51-obexd_without_systemd-1.patch
@@ -16,24 +16,22 @@ directly, and to do so it needs the full path of the daemon.
  delete mode 100644 obexd/src/org.bluez.obex.service
  create mode 100644 obexd/src/org.bluez.obex.service.in
 
-diff --git a/Makefile.obexd b/Makefile.obexd
-index 3760867..142e7c3 100644
---- a/Makefile.obexd
-+++ b/Makefile.obexd
-@@ -2,12 +2,12 @@
+--- ./Makefile.obexd.orig	2019-09-19 13:51:02.000000000 -0500
++++ ./Makefile.obexd	2019-09-20 14:10:10.647348607 -0500
+@@ -1,12 +1,12 @@
  if SYSTEMD
- systemduserunitdir = @SYSTEMD_USERUNITDIR@
+ systemduserunitdir = $(SYSTEMD_USERUNITDIR)
  systemduserunit_DATA = obexd/src/obex.service
 +endif
  
- dbussessionbusdir = @DBUS_SESSIONBUSDIR@
+ dbussessionbusdir = $(DBUS_SESSIONBUSDIR)
  dbussessionbus_DATA = obexd/src/org.bluez.obex.service
 -endif
  
 -EXTRA_DIST += obexd/src/obex.service.in obexd/src/org.bluez.obex.service
 +EXTRA_DIST += obexd/src/obex.service.in obexd/src/org.bluez.obex.service.in
  
- obex_plugindir = $(libdir)/obex/plugins
+ if OBEX
  
 diff --git a/obexd/src/org.bluez.obex.service b/obexd/src/org.bluez.obex.service
 deleted file mode 100644
@@ -53,7 +51,7 @@ index 0000000..9c815f2
 @@ -0,0 +1,4 @@
 +[D-BUS Service]
 +Name=org.bluez.obex
-+Exec=@libexecdir@/obexd
++Exec=@pkglibexecdir@/obexd
 +SystemdService=dbus-org.bluez.obex.service
 -- 
 1.8.3.1

--- a/plamo/05_ext/bluez/btusb.conf
+++ b/plamo/05_ext/bluez/btusb.conf
@@ -1,0 +1,3 @@
+# use "reset=1" as default, since it should be safe for recent devices and
+# solves all kind of problems.
+options btusb reset=1

--- a/plamo/05_ext/bluez/refresh_adv_manager_for_non-LE_devices.diff
+++ b/plamo/05_ext/bluez/refresh_adv_manager_for_non-LE_devices.diff
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<title>refresh_adv_manager_for_non-LE_devices.diff\trunk - svntogit/packages.git - Git clone of the 'packages' repository
+</title>
+<meta name='generator' content='cgit v1.2.1-1-g437b'/>
+<meta name='robots' content='index, nofollow'/>
+<link rel='stylesheet' type='text/css' href='/cgit.css'/>
+<link rel='shortcut icon' href='/favicon.ico'/>
+<link rel='alternate' title='Atom feed' href='https://git.archlinux.org/svntogit/packages.git/atom/trunk/refresh_adv_manager_for_non-LE_devices.diff?h=packages/bluez' type='application/atom+xml'/>
+<link rel='vcs-git' href='https://git.archlinux.org/svntogit/packages.git' title='svntogit/packages.git Git repository'/>
+<link rel='vcs-git' href='git://git.archlinux.org/svntogit/packages.git' title='svntogit/packages.git Git repository'/>
+<link rel='vcs-git' href='ssh://git.archlinux.org/srv/git/svntogit/packages.git' title='svntogit/packages.git Git repository'/>
+</head>
+<body>
+	<div id="archnavbar"><!-- Arch Linux global navigation bar -->
+		<div id="archnavbarlogo">
+			<p><a href="http://www.archlinux.org/" title="Arch news, packages, projects and more"></a></p>
+		</div>
+		<div id="archnavbarmenu">
+			<ul id="archnavbarlist">
+				<li id="anb-home"><a href="http://www.archlinux.org/" title="Arch news, packages, projects and more">Home</a></li>
+				<li id="anb-packages"><a href="http://www.archlinux.org/packages/" title="Arch Package Database">Packages</a></li>
+				<li id="anb-forums"><a href="https://bbs.archlinux.org/" title="Community forums">Forums</a></li>
+				<li id="anb-wiki"><a href="https://wiki.archlinux.org/" title="Community documentation">Wiki</a></li>
+				<li id="anb-bugs"><a href="https://bugs.archlinux.org/" title="Report and follow bugs">Bugs</a></li>
+				<li id="anb-sec"><a href="https://security.archlinux.org/" title="Security Tracker">Security</a></li>
+				<li id="anb-aur"><a href="https://aur.archlinux.org/" title="Arch Linux User Repository">AUR</a></li>
+				<li id="anb-download"><a href="http://www.archlinux.org/download/" title="Get Arch Linux">Download</a></li>
+			</ul>
+		</div>
+	</div><!-- #archnavbar -->
+<div id='cgit'><table id='header'>
+<tr>
+<td class='main'><a href='/'>index</a> : <a title='svntogit/packages.git' href='/svntogit/packages.git/'>svntogit/packages.git</a></td></tr>
+<tr><td class='sub'>Git clone of the 'packages' repository
+</td><td class='sub right'></td></tr></table>
+<table class='tabs'><tr><td>
+<a href='/svntogit/packages.git/?h=packages/bluez'>summary</a><a href='/svntogit/packages.git/refs/?h=packages/bluez'>refs</a><a href='/svntogit/packages.git/log/trunk/refresh_adv_manager_for_non-LE_devices.diff?h=packages/bluez'>log</a><a class='active' href='/svntogit/packages.git/tree/trunk/refresh_adv_manager_for_non-LE_devices.diff?h=packages/bluez'>tree</a><a href='/svntogit/packages.git/commit/trunk/refresh_adv_manager_for_non-LE_devices.diff?h=packages/bluez'>commit</a><a href='/svntogit/packages.git/diff/trunk/refresh_adv_manager_for_non-LE_devices.diff?h=packages/bluez'>diff</a><a href='/svntogit/packages.git/stats/trunk/refresh_adv_manager_for_non-LE_devices.diff?h=packages/bluez'>stats</a></td><td class='form'><form class='right' method='get' action='/svntogit/packages.git/log/trunk/refresh_adv_manager_for_non-LE_devices.diff'>
+<input type='hidden' name='h' value='packages/bluez'/><select name='qt'>
+<option value='grep'>log msg</option>
+<option value='author'>author</option>
+<option value='committer'>committer</option>
+<option value='range'>range</option>
+</select>
+<input class='txt' type='search' size='10' name='q' value=''/>
+<input type='submit' value='search'/>
+</form>
+</td></tr></table>
+<div class='path'>path: <a href='/svntogit/packages.git/tree/?h=packages/bluez'>root</a>/<a href='/svntogit/packages.git/tree/trunk?h=packages/bluez'>trunk</a>/<a href='/svntogit/packages.git/tree/trunk/refresh_adv_manager_for_non-LE_devices.diff?h=packages/bluez'>refresh_adv_manager_for_non-LE_devices.diff</a></div><div class='content'>blob: 922d9d383b03810eca524757b1783c8739abf300 (<a href='/svntogit/packages.git/plain/trunk/refresh_adv_manager_for_non-LE_devices.diff?h=packages/bluez'>plain</a>)
+<table summary='blob content' class='blob'>
+<tr><td class='linenumbers'><pre><a id='n1' href='#n1'>1</a>
+<a id='n2' href='#n2'>2</a>
+<a id='n3' href='#n3'>3</a>
+<a id='n4' href='#n4'>4</a>
+<a id='n5' href='#n5'>5</a>
+<a id='n6' href='#n6'>6</a>
+<a id='n7' href='#n7'>7</a>
+<a id='n8' href='#n8'>8</a>
+<a id='n9' href='#n9'>9</a>
+<a id='n10' href='#n10'>10</a>
+<a id='n11' href='#n11'>11</a>
+<a id='n12' href='#n12'>12</a>
+<a id='n13' href='#n13'>13</a>
+<a id='n14' href='#n14'>14</a>
+<a id='n15' href='#n15'>15</a>
+<a id='n16' href='#n16'>16</a>
+<a id='n17' href='#n17'>17</a>
+<a id='n18' href='#n18'>18</a>
+<a id='n19' href='#n19'>19</a>
+<a id='n20' href='#n20'>20</a>
+<a id='n21' href='#n21'>21</a>
+<a id='n22' href='#n22'>22</a>
+<a id='n23' href='#n23'>23</a>
+<a id='n24' href='#n24'>24</a>
+<a id='n25' href='#n25'>25</a>
+<a id='n26' href='#n26'>26</a>
+<a id='n27' href='#n27'>27</a>
+<a id='n28' href='#n28'>28</a>
+<a id='n29' href='#n29'>29</a>
+<a id='n30' href='#n30'>30</a>
+<a id='n31' href='#n31'>31</a>
+<a id='n32' href='#n32'>32</a>
+<a id='n33' href='#n33'>33</a>
+<a id='n34' href='#n34'>34</a>
+<a id='n35' href='#n35'>35</a>
+<a id='n36' href='#n36'>36</a>
+<a id='n37' href='#n37'>37</a>
+<a id='n38' href='#n38'>38</a>
+<a id='n39' href='#n39'>39</a>
+<a id='n40' href='#n40'>40</a>
+<a id='n41' href='#n41'>41</a>
+<a id='n42' href='#n42'>42</a>
+<a id='n43' href='#n43'>43</a>
+<a id='n44' href='#n44'>44</a>
+<a id='n45' href='#n45'>45</a>
+<a id='n46' href='#n46'>46</a>
+<a id='n47' href='#n47'>47</a>
+<a id='n48' href='#n48'>48</a>
+<a id='n49' href='#n49'>49</a>
+<a id='n50' href='#n50'>50</a>
+<a id='n51' href='#n51'>51</a>
+<a id='n52' href='#n52'>52</a>
+</pre></td>
+<td class='lines'><pre><code>From 2c3bba7b38be03834162e34069156f1fd49f0528 Mon Sep 17 00:00:00 2001
+From: &quot;antoine.belvire&#64;laposte.net&quot; &lt;antoine.belvire&#64;laposte.net&gt;
+Date: Tue, 27 Mar 2018 20:30:26 +0200
+Subject: adapter: Don&#39;t refresh adv_manager for non-LE devices
+
+btd_adv_manager_refresh is called upon MGMT_SETTING_DISCOVERABLE setting change
+but as only LE adapters have an adv_manager, this leads to segmentation fault
+for non-LE devices:
+
+0  btd_adv_manager_refresh (manager=0x0) at src/advertising.c:1176
+1  0x0000556fe45fcb02 in settings_changed (settings=&lt;optimized out&gt;,
+    adapter=0x556fe53f7c70) at src/adapter.c:543
+2  new_settings_callback (index=&lt;optimized out&gt;, length=&lt;optimized out&gt;,
+    param=&lt;optimized out&gt;, user_data=0x556fe53f7c70) at src/adapter.c:573
+3  0x0000556fe462c278 in request_complete (mgmt=mgmt&#64;entry=0x556fe53f20c0,
+    status=&lt;optimized out&gt;, opcode=opcode&#64;entry=7, index=index&#64;entry=0,
+    length=length&#64;entry=4, param=0x556fe53eb5f9) at src/shared/mgmt.c:261
+4  0x0000556fe462cd9d in can_read_data (io=&lt;optimized out&gt;,
+    user_data=0x556fe53f20c0) at src/shared/mgmt.c:353
+5  0x0000556fe46396e3 in watch_callback (channel=&lt;optimized out&gt;,
+    cond=&lt;optimized out&gt;, user_data=&lt;optimized out&gt;)
+    at src/shared/io-glib.c:170
+6  0x00007fe351c980e5 in g_main_context_dispatch ()
+   from /usr/lib64/libglib-2.0.so.0
+7  0x00007fe351c984b0 in ?? () from /usr/lib64/libglib-2.0.so.0
+8  0x00007fe351c987c2 in g_main_loop_run () from /usr/lib64/libglib-2.0.so.0
+9  0x0000556fe45abc75 in main (argc=&lt;optimized out&gt;, argv=&lt;optimized out&gt;)
+    at src/main.c:770
+
+This commit prevents the call to btd_adv_manager_refresh for non-LE devices.
+<span class="hl kwa">---</span>
+ src/adapter.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/adapter.c b/src/adapter.c
+index 6b9222b..daccfdc 100644
+<span class="hl kwa">--- a/src/adapter.c</span>
+<span class="hl kwb">+++ b/src/adapter.c</span>
+&#64;&#64; -540,7 +540,8 &#64;&#64; static void settings_changed(struct btd_adapter *adapter, uint32_t settings)
+ 		g_dbus_emit_property_changed(dbus_conn, adapter-&gt;path,
+ 					ADAPTER_INTERFACE, &quot;Discoverable&quot;);
+ 		store_adapter_info(adapter);
+<span class="hl kwa">-		btd_adv_manager_refresh(adapter-&gt;adv_manager);</span>
+<span class="hl kwb">+		if (adapter-&gt;supported_settings &amp; MGMT_SETTING_LE)</span>
+<span class="hl kwb">+			btd_adv_manager_refresh(adapter-&gt;adv_manager);</span>
+ 	}
+ 
+ 	if (changed_mask &amp; MGMT_SETTING_BONDABLE) {
+<span class="hl kwa">-- </span>
+cgit v1.1
+
+
+</code></pre></td></tr></table>
+</div> <!-- class=content -->
+<div class="foot" style="padding-left:1em;padding-right:1em;">
+<p>Copyright &copy; 2002-2018 <a href="mailto:jvinet@zeroflux.org"
+title="contact Judd Vinet">Judd Vinet</a> and <a href="mailto:aaron@archlinux.org"
+title="contact Aaron Griffin">Aaron Griffin</a>. The Arch Linux name and logo
+are recognized trademarks. Some rights reserved. The registered trademark
+Linux&reg; is used pursuant to a sublicense from LMI, the exclusive licensee
+of Linus Torvalds, owner of the mark on a world-wide basis.</p>
+</div>
+</div> <!-- id=cgit -->
+</body>
+</html>


### PR DESCRIPTION
obexd 用のパッチ（systemd でなく dbus から稼働させるためのもの、たぶん）
が間違っていて、パスが置き換えられずに "@libexecdir@" みたいな置換前の
文字列のまま入っており、obexd を起動できずに、そのためにインストールさ
れるファイルが無意味になっていた。(slackware も gentoo も同じパッチ当
ててるけど動いてないんじゃ…）