### PR TITLE
plamo/01_minimum/libidn2: 2.2.0

### DIFF
--- a/plamo/01_minimum/libidn2/PlamoBuild.libidn2-2.2.0
+++ b/plamo/01_minimum/libidn2/PlamoBuild.libidn2-2.2.0
@@ -1,7 +1,7 @@
 #!/bin/sh
 ##############################################################
 pkgbase="libidn2"
-vers="2.1.1"
+vers="2.2.0"
 url="https://ftp.gnu.org/gnu/libidn/libidn2-${vers}.tar.gz"
 verify="${url}.sig"
 digest=""


### PR DESCRIPTION
最新パッケージのビルドスクリプトに合わせただけ（パッケージビルドなし）