### PR TITLE
plamo/08_daemons/php: 7.4.3 cgi版を復活

### DIFF
--- a/plamo/08_daemons/php/0001-Disable-MPM-detection-in-configure-Always-build-NTS.patch
+++ b/plamo/08_daemons/php/0001-Disable-MPM-detection-in-configure-Always-build-NTS.patch
@@ -1,0 +1,35 @@
+From 003b757e706e01e374f248856ba1e9f2b3404a79 Mon Sep 17 00:00:00 2001
+From: KATOH Yasufumi <karma@jazz.email.ne.jp>
+Date: Thu, 27 Feb 2020 18:15:19 +0900
+Subject: [PATCH] Disable MPM detection in configure. Always build NTS
+ (non-ZTS)
+
+---
+ sapi/apache2handler/config.m4 | 11 -----------
+ 1 file changed, 11 deletions(-)
+
+diff --git a/sapi/apache2handler/config.m4 b/sapi/apache2handler/config.m4
+index 55c16179..38b10851 100644
+--- a/sapi/apache2handler/config.m4
++++ b/sapi/apache2handler/config.m4
+@@ -105,17 +105,6 @@ if test "$PHP_APXS2" != "no"; then
+     ;;
+   esac
+ 
+-  if test "$APACHE_VERSION" -lt 2004001; then
+-    APXS_MPM=`$APXS -q MPM_NAME`
+-    if test "$APXS_MPM" != "prefork" && test "$APXS_MPM" != "peruser" && test "$APXS_MPM" != "itk"; then
+-      PHP_BUILD_THREAD_SAFE
+-    fi
+-  else
+-    APACHE_THREADED_MPM=`$APXS_HTTPD -V 2>/dev/null | grep 'threaded:.*yes'`
+-    if test -n "$APACHE_THREADED_MPM"; then
+-      PHP_BUILD_THREAD_SAFE
+-    fi
+-  fi
+   AC_MSG_RESULT(yes)
+   PHP_SUBST(APXS)
+ else
+-- 
+2.24.1
+

--- a/plamo/08_daemons/php/PlamoBuild.php-7.4.3
+++ b/plamo/08_daemons/php/PlamoBuild.php-7.4.3
@@ -1,7 +1,7 @@
 #!/bin/sh
 ##############################################################
 pkgbase="php"
-vers="7.4.2"
+vers="7.4.3"
 url="https://www.php.net/distributions/php-${vers}.tar.xz"
 verify="${url}.asc"
 digest=""
@@ -11,7 +11,7 @@ src="php-${vers}"
 OPT_CONFIG=()
 BUILD_TYPE=(apache cgi)
 DOCS="LICENSE NEWS README.REDIST.BINS README.md"
-patchfiles=""
+patchfiles="0001-Disable-MPM-detection-in-configure-Always-build-NTS.patch"
 # specifies files that are not in source archive and patchfiles
 addfiles="php7.conf php-fpm.init"
 compress=txz
@@ -20,7 +20,8 @@ compress=txz
 source /usr/share/plamobuild_functions.sh
 
 # 共通オプション
-OPT_CONFIG=(--srcdir=$B
+OPT_CONFIG=("${OPT_CONFIG[@]}"
+	    --srcdir=$B
 	    --config-cache
 	    --prefix=/usr
 	    --sysconfdir=/etc/php
@@ -29,8 +30,10 @@ OPT_CONFIG=(--srcdir=$B
 	    --with-config-file-path=/etc/php
 	    --with-config-file-scan-dir=/etc/php/conf.d
 	    --disable-rpath
-	    --mandir=/usr/share/man
-	    --enable-bcmath=shared
+	    --mandir=/usr/share/man)
+
+# 拡張
+OPT_MODULE=(--enable-bcmath=shared
 	    --enable-calendar=shared
 	    --enable-dba=shared
 	    --enable-exif=shared
@@ -70,15 +73,20 @@ OPT_CONFIG=(--srcdir=$B
 	    --with-xmlrpc=shared
 	    --with-xsl=shared
 	    --with-zip=shared
-	    --with-zlib
-	    --enable-fpm
-	    --with-fpm-acl
-	    --with-fpm-user=www
-	    --with-fpm-group=apache
-	    --with-apxs2=/usr/bin/apxs)
+	    --with-zlib)
+
+OPT_CONFIG_cgi=(--enable-cgi
+		--enable-fpm
+		--with-fpm-acl
+		--with-fpm-user=www
+		--with-fpm-group=apache
+		--enable-embed=shared
+		${OPT_MODULE[@]})
+
+OPT_CONFIG_apache=(--with-apxs2=/usr/bin/apxs
+		   ${OPT_MODULE[@]})
 
 export EXTENSION_DIR=/usr/${libdir}/php/modules
-export CXXFLAGS="$CXXFLAGS -DU_USING_ICU_NAMESPACE=1"
 
 if [ $# -eq 0 ] ; then
   opt_download=0 ; opt_config=1 ; opt_build=1 ; opt_package=1
@@ -116,65 +124,83 @@ if [ $opt_config -eq 1 ] ; then
         patch -p1 < $W/$patch
     done
 
-    sed -i "s|build$|php/build|" scripts/Makefile.frag
-    sed -i "s|build\"$|php/build\"|" scripts/phpize.in
+    mkdir cgi apache
 
-    ./configure ${OPT_CONFIG[@]}
+    echo "=== configure cgi/fpm ==="
+    pushd cgi
+    ln -s ../configure
+    ./configure ${OPT_CONFIG[@]} ${OPT_CONFIG_cgi[@]}
     if [ $? != 0 ]; then
       echo "configure error. $0 script stop"
       exit 255
     fi
+    popd
+
+    echo "=== configure apache ==="
+    pushd apache
+    ln -s ../configure
+    ./configure ${OPT_CONFIG[@]} ${OPT_CONFIG_apache[@]}
+    if [ $? != 0 ]; then
+      echo "configure error. $0 script stop"
+      exit 255
+    fi
+    popd
 fi
 
 if [ $opt_build -eq 1 ] ; then
-    cd $B
-    make -j3
-    if [ $? != 0 ]; then
-        echo "build error. $0 script stop"
-        exit 255
-    fi
+    for t in ${BUILD_TYPE[@]}
+    do
+	cd $B/$t
+	echo "=== build $t ==="
+	export LDFLAGS='-Wl,--as-needed'
+	make
+	if [ $? != 0 ]; then
+            echo "build error. $0 script stop"
+            exit 255
+	fi
+    done
 fi
 
 if [ $opt_package -eq 1 ] ; then
-    check_root
-    if [ -d $P ] ; then rm -rf $P ; fi ; mkdir -p $P
-    cd $B
+  check_root
+  if [ -d $P ] ; then rm -rf $P ; fi ; mkdir -p $P
+  cd $B
 
-    # install dummy httpd.conf
-    echo "Install dummy apache httpd.conf"
-    install -dm755 -v $P/etc/httpd
-    cp -v /etc/httpd/original/httpd.conf $P/etc/httpd/
+  pushd cgi
+  make -j1 INSTALL_ROOT=$P install-{modules,cli,build,headers,programs,pharcmd}
+  make -j1 INSTALL_ROOT=$P install-cgi
+  make -j1 INSTALL_ROOT=$P install-fpm
+  install -D -m644 -v $B/php.ini-production $P/etc/php/php.ini.dist
+  install -d -m755 -v $P/etc/php/conf.d/
+  popd
 
-    make -j1 INSTALL_ROOT=$P install
-    install -D -m644 -v $B/php.ini-production $P/etc/php/php.ini.dist
-    install -d -m755 -v $P/etc/php/conf.d/
+  pushd apache
+  install -Dm755 libs/libphp7.so $P/usr/${libdir}/httpd/modules/libphp7.so
+  popd
 
-    # delete unneeded files
-    rm -fv $P/etc/httpd/httpd.conf*
-    ( cd $P ; rm -rfv .channels .depdb .filemap .lock .registry .depdblock )
-    rm -rfv $P/var
-    rm -fv $P/usr/${libdir}/php/extensions/*.a
+  ( cd $P ; rm -rfv .channels .depdb .filemap .lock .registry .depdblock )
+  rm -rfv $P/var
 
-    install -Dm644 -v $W/php7.conf $P/etc/httpd/extra.dist/php7.conf
-    install -Dm644 -v $W/php7.conf $docdir/$src/php7.conf
+  install -Dm644 -v $W/php7.conf $P/etc/httpd/extra.dist/php7.conf
+  install -Dm644 -v $W/php7.conf $docdir/$src/php7.conf
 
-    # php-fpm init
-    install -Dm644 -v $W/php-fpm.init $P/etc/rc.d/init.d/php-fpm
-    for i in $(seq 0 6)
-    do
-	install -dm755 -v $P/etc/rc.d/rc"$i".d
-	case $i in
-	    0|1|2|6)
-		ln -sfv ../init.d/php-fpm $P/etc/rc.d/rc"$i".d/K28php-fpm
-		;;
-	    3|4|5)
-		ln -sfv ../init.d/php-fpm $P/etc/rc.d/rc"$i".d/S32php-fpm
-		;;
-	esac
-    done
+  # php-fpm init
+  install -Dm644 -v $W/php-fpm.init $P/etc/rc.d/init.d/php-fpm
+  for i in $(seq 0 6)
+  do
+    install -dm755 -v $P/etc/rc.d/rc"$i".d
+    case $i in
+      0|1|2|6)
+        ln -sfv ../init.d/php-fpm $P/etc/rc.d/rc"$i".d/K28php-fpm
+	;;
+      3|4|5)
+	ln -sfv ../init.d/php-fpm $P/etc/rc.d/rc"$i".d/S32php-fpm
+	;;
+    esac
+  done
 
-    mkdir -p $P/install
-    cat <<EOF >> $P/install/initpkg
+  mkdir -p $P/install
+  cat <<EOF >> $P/install/initpkg
 if [ ! -f /etc/httpd/extra/php7.conf ]; then
   ( cd /etc/httpd ; cp extra.dist/php7.conf extra/php7.conf )
 fi
@@ -190,21 +216,21 @@ fi
 EOF
 
 
-    ################################
-    #      install tweaks
-    #  strip binaries, delete locale except ja, compress man,
-    #  install docs and patches, compress them and  chown root.root
-    ################################
-    install_tweak
+################################
+#      install tweaks
+#  strip binaries, delete locale except ja, compress man,
+#  install docs and patches, compress them and  chown root.root
+################################
+  install_tweak
 
-    #############################
-    #   convert symlink to null file and
-    #   add "ln -sf" command into install/doinst.sh
-    ################################
-    convert_links
+#############################
+#   convert symlink to null file and
+#   add "ln -sf" command into install/doinst.sh
+################################
+  convert_links
 
-    cd $P
-    /sbin/makepkg ../$pkg.$compress <<EOF
+  cd $P
+  /sbin/makepkg ../$pkg.$compress <<EOF
 y
 1
 EOF


### PR DESCRIPTION
configure時にApacheの設定を見てNTS版、ZTS版のどちらをビルドするかを選
択するようになっていたのを、常にNTS版を選択するようにパッチを適用。