### PR TITLE
plamo/07_multimedia/firefox: 76.0 B2

### DIFF
--- a/plamo/07_multimedia/firefox/PlamoBuild.firefox-76.0
+++ b/plamo/07_multimedia/firefox/PlamoBuild.firefox-76.0
@@ -8,13 +8,13 @@ langpack_ja="https://ftp.mozilla.org/pub/firefox/releases/${vers}/linux-x86_64/x
 verify="${url}.asc"
 digest=""
 arch=`uname -m`
-build=B1
+build=B2
 src="firefox-${vers}"
 OPT_CONFIG=
 DOCS='AUTHORS LICENSE README.txt other-licenses sourcestamp.txt'
 #blfspatch="http://www.linuxfromscratch.org/patches/blfs/svn/firefox-68.2.0esr-system_graphite2_harfbuzz-1.patch"
 #patchfiles="${blfspatch##*/}"
-addfiles="firefox.desktop langpack.sh mozconfig vendor.js"
+addfiles="firefox.desktop langpack.sh mozconfig vendor-firefox.js vendor-gre.js"
 compress=txz
 
 rustver=""
@@ -176,10 +176,14 @@ if [ $opt_package -eq 1 ] ; then
   sh $W/langpack.sh $W
   install -Dm644 -v $W/ja.xpi.plamo \
           $P/usr/${libdir}/firefox/browser/extensions/langpack-ja@firefox.mozilla.org.xpi
-  install -Dm644 -v $W/vendor.js \
-          $P/usr/${libdir}/firefox/browser/defaults/preferences/vendor.js
-  install -Dm644 -v $W/vendor.js \
-          $docdir/$src/vendor.js
+  install -Dm644 -v $W/vendor-firefox.js \
+          $P/usr/${libdir}/firefox/browser/defaults/preferences/vendor-firefox.js
+  install -Dm644 -v $W/vendor-gre.js \
+	  $P/usr/${libdir}/firefox/defaults/pref/vendor-gre.js
+  install -Dm644 -v $W/vendor-firefox.js \
+          $docdir/$src/vendor-firefox.js
+  install -Dm644 -v $W/vendor-gre.js \
+	  $docdir/$src/vendor-gre.js
 
 ################################
 #      install tweaks

--- a/plamo/07_multimedia/firefox/mozconfig
+++ b/plamo/07_multimedia/firefox/mozconfig
@@ -52,5 +52,8 @@ ac_add_options --disable-official-branding
 ac_add_options --with-branding=browser/branding/unofficial
 ac_add_options --with-distribution-id=org.plamolinux
 
+ac_add_options --with-unsigned-addon-scopes=app,system
+ac_add_options --allow-addon-sideload
+
 mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/../build
 #mk_add_options MOZ_MAKE_FLAGS="-j3"

--- a/plamo/07_multimedia/firefox/vendor-firefox.js
+++ b/plamo/07_multimedia/firefox/vendor-firefox.js
@@ -1,11 +1,11 @@
-// Use LANG environment variable to choose locale
-pref("intl.locale.requested", "");
-
 // Disable default browser checking.
 pref("browser.shell.checkDefaultBrowser", false);
 
 // Don't disable our bundled extensions in the application directory
-pref("extensions.autoDisableScopes", 11);
+pref("extensions.autoDisableScopes", 3);
+
+// Don't display the one-off addon selection dialog when
+// upgrading from a version of Firefox older than 8.0
 pref("extensions.shownSelectionUI", true);
 
 // for using Plamo original langpack

--- a/plamo/07_multimedia/firefox/vendor-gre.js
+++ b/plamo/07_multimedia/firefox/vendor-gre.js
@@ -1,0 +1,11 @@
+// Use LANG environment variable to choose locale
+pref("intl.locale.matchOS", true);
+
+// Enable Network Manager integration
+pref("network.manage-offline-status", true);
+
+// Use the system locale. Note that this doesn't work correctly in
+// distribution.ini as this pref needs to be initialized before
+// distribution.ini prefs are applied, in order for locale-specific prefs
+// to work
+pref("intl.locale.requested", "");


### PR DESCRIPTION
初回起動時（プロファイルがないとき）に起動すると、Plamo 作成の日本語パッ
クが読み込まれない問題に対応