### PR TITLE
plamo/00_base/linux_pam: 1.4.0 B3

### DIFF
--- a/plamo/00_base/linux_pam/PlamoBuild.linux_pam-1.4.0
+++ b/plamo/00_base/linux_pam/PlamoBuild.linux_pam-1.4.0
@@ -6,9 +6,9 @@ url="https://github.com/linux-pam/linux-pam/releases/download/v${vers}/Linux-PAM
 digest="md5sum:39fca0523bccec6af4b63b5322276c84"
 doc_url="https://github.com/linux-pam/linux-pam/releases/download/v${vers}/Linux-PAM-${vers}-docs.tar.xz"
 arch=`uname -m`
-build=B2
+build=B3
 src="Linux-PAM-${vers}"
-OPT_CONFIG="--enable-read-both-confs --disable-nis --disable-db --disable-regenerate-docu"
+OPT_CONFIG="--enable-read-both-confs --disable-nis --disable-db --disable-regenerate-docu --enable-cracklib"
 DOCS='ABOUT-NLS AUTHORS CHANGELOG COPYING ChangeLog ChangeLog-CVS INSTALL NEWS README'
 patchfiles=''
 # specifies files that are not in source archive and patchfiles


### PR DESCRIPTION
互換性のために pam_cracklib.so をビルドするようにした