### PR TITLE
plamo/01_minimum/get_pkginfo: 3.0

### DIFF
--- a/plamo/01_minimum/get_pkginfo/PlamoBuild.get_pkginfo-3.0
+++ b/plamo/01_minimum/get_pkginfo/PlamoBuild.get_pkginfo-3.0
@@ -1,0 +1,91 @@
+#!/bin/sh
+##############################################################
+pkgbase='get_pkginfo'
+vers='3.0'
+url="https://github.com/plamolinux/get_pkginfo/archive/${vers}.tar.gz"
+arch="noarch"
+build=B1
+src="${pkgbase}-${vers}"
+OPT_CONFIG=''
+DOCS='README.md'
+patchfiles=''
+compress=txz
+##############################################################
+
+source /usr/share/plamobuild_functions.sh
+
+# このスクリプトで使う1文字変数の意味
+# 
+# $W : このスクリプトを動かすカレントディレクトリ
+# $S : ソースコードのあるディレクトリ(デフォルト: $W/${src})
+# $B : ビルド用ディレクトリ(デフォルト: /tmp/build{,32})
+# $P : ビルドしたファイルをインストールするディレクトリ（デフォルト: $W/work)
+
+
+if [ $# -eq 0 ] ; then
+  opt_download=0 ; opt_config=1 ; opt_build=1 ; opt_package=1
+else
+  opt_download=0 ; opt_config=0 ; opt_build=0 ; opt_package=0
+  for i in $@ ; do
+    case $i in
+    download) opt_download=1 ;;
+    config) opt_config=1 ;;
+    build) opt_build=1 ;;
+    package) opt_package=1 ;;
+    esac
+  done
+fi
+if [ $opt_download -eq 1 ] ; then
+    download_sources
+fi
+
+if [ $opt_config -eq 1 ] ; then
+######################################################################
+#  don't copy sources, so need patch in the src dir
+######################################################################
+    cd $S
+    for patch in $patchfiles ; do
+        if [ ! -f .${patch} ]; then
+            patch -p1 < $W/$patch
+            touch .${patch}
+        fi
+    done
+    echo "no need to config. proceed to build."
+    opt_build=1
+fi
+    
+if [ $opt_build -eq 1 ] ; then
+    cd $S
+    echo "no need to build. proceed to package."
+fi
+
+if [ $opt_package -eq 1 ] ; then
+  check_root
+  if [ -d $P ] ; then rm -rf $P ; fi ; mkdir -p $P
+  mkdir -p $P/usr/bin
+  mkdir -p $P/usr/share/doc/${pkgbase}-${vers}
+
+  cd $S
+  install get_pkginfo.py $P/usr/bin/get_pkginfo
+  install $W/$0 $P/usr/share/doc/${pkgbase}-${vers}
+
+################################
+#      install tweaks
+#  strip binaries, delete locale except ja, compress man, 
+#  install docs and patches, compress them and  chown root.root
+################################
+  install_tweak
+
+#############################
+#   convert symlink to null file and 
+#   add "ln -sf" command into install/doinst.sh
+################################
+  convert_links
+
+  cd $P
+  /sbin/makepkg ../$pkg.$compress <<EOF
+y
+1
+EOF
+
+fi


### PR DESCRIPTION
* python3 対応
* -tを指定したときのみcontribを対象にするようにした
* blocklistはパッケージ名の一部を指定するようになった