### PR TITLE
plamo/01_minimum/get_pkginfo: 3.3

### DIFF
--- a/plamo/01_minimum/get_pkginfo/PlamoBuild.get_pkginfo-3.3
+++ b/plamo/01_minimum/get_pkginfo/PlamoBuild.get_pkginfo-3.3
@@ -1,7 +1,7 @@
 #!/bin/sh
 ##############################################################
 pkgbase='get_pkginfo'
-vers='3.2'
+vers='3.3'
 url="https://github.com/plamolinux/get_pkginfo/archive/${vers}.tar.gz"
 arch="noarch"
 build=B1


### PR DESCRIPTION
urllib.FancyURLopener 関連のエラーのさらなる修正（ftpのとき）