### PR TITLE
plamo/01_minimum/libxml2: 2.9.12

### DIFF
--- a/plamo/01_minimum/libxml2/PlamoBuild.libxml2-2.9.12
+++ b/plamo/01_minimum/libxml2/PlamoBuild.libxml2-2.9.12
@@ -1,13 +1,13 @@
 #!/bin/sh
 ##############################################################
 pkgbase='libxml2'
-vers='2.9.10'
+vers='2.9.12'
 url="ftp://xmlsoft.org/${pkgbase}/${pkgbase}-${vers}.tar.gz"
 verify="${url}.asc"
 arch=`uname -m`
-build=B2
+build=B1
 src="${pkgbase}-${vers}"
-OPT_CONFIG='--disable-static --with-history --with-threads'
+OPT_CONFIG='--disable-static --with-history --with-threads --without-icu'
 DOCS='AUTHORS COPYING ChangeLog INSTALL NEWS README README.tests TODO TODO_SCHEMAS'
 blfspatch=""
 patchfiles=""


### PR DESCRIPTION
icuに依存しないようにした