### PR TITLE
plamo/00_base/libcap: 2.51

### DIFF
--- a/plamo/00_base/libcap/PlamoBuild.libcap-2.51
+++ b/plamo/00_base/libcap/PlamoBuild.libcap-2.51
@@ -1,15 +1,15 @@
 #!/bin/sh
 ##############################################################
 pkgbase='libcap'
-vers='2.50'
+vers='2.51'
 url="https://kernel.org/pub/linux/libs/security/linux-privs/${pkgbase}2/${pkgbase}-${vers}.tar.xz"
 #verify="https://mirrors.edge.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-${vers}.tar.sign"
 arch=`uname -m`
-build=B2
+build=B1
 src="libcap-${vers}"
 OPT_CONFIG='--disable-static --enable-shared'
 DOCS='CHANGELOG License README pam_cap/capability.conf'
-patchfiles='0001-Make-capsh-an-installed-binary-again.patch'
+patchfiles=''
 compress=txz
 ##############################################################
 
@@ -76,6 +76,8 @@ if [ $opt_package -eq 1 ] ; then
   rm -vf $P/${libdir}/libcap.so
   mkdir -pv $P/usr/lib
   ln -sv /${libdir}/$(readlink $P/${libdir}/libcap.so.2) $P/usr/${libdir}/libcap.so
+
+  mv -v $P/${libdir}/pkgconfig $P/usr/lib/pkgconfig
 
 ################################
 #      install tweaks


### PR DESCRIPTION
pkgconfig が /lib/pkgconfig にいたので /usr/lib に移動