### PR TITLE
plamo/03_libs/freetype: 2.11.0 B2

### DIFF
--- a/plamo/03_libs/freetype/0005-Restore-quiet-no_op-rendering.patch
+++ b/plamo/03_libs/freetype/0005-Restore-quiet-no_op-rendering.patch
@@ -1,0 +1,41 @@
+From 6e9d8d314ff6ab23177b9162c0b96616460bb84e Mon Sep 17 00:00:00 2001
+From: Alexei Podtelezhnikov <apodtele@gmail.com>
+Date: Fri, 20 Aug 2021 16:01:32 -0400
+Subject: [PATCH] [base] Restore quiet no-op rendering of bitmap glyphs.
+
+Fixes #1076.
+
+* src/base/ftobjs.c (FT_Render_Glyph_Internal): Discard an error when
+rendering a bitmap glyph.
+---
+ src/base/ftobjs.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/base/ftobjs.c b/src/base/ftobjs.c
+index 342ac4a27..7b40c6421 100644
+--- a/src/base/ftobjs.c
++++ b/src/base/ftobjs.c
+@@ -4703,7 +4703,7 @@
+         else
+           renderer = FT_Lookup_Renderer( library, slot->format, &node );
+ 
+-        error = FT_ERR( Unimplemented_Feature );
++        error = FT_ERR( Cannot_Render_Glyph );
+         while ( renderer )
+         {
+           error = renderer->render( renderer, slot, render_mode, NULL );
+@@ -4719,6 +4719,11 @@
+           /* format.                                               */
+           renderer = FT_Lookup_Renderer( library, slot->format, &node );
+         }
++
++        /* it is not an error if we cannot render a bitmat glyph */
++        if ( FT_ERR_EQ( error, Cannot_Render_Glyph ) &&
++             slot->format == FT_GLYPH_FORMAT_BITMAP  )
++          error = FT_Err_Ok;
+       }
+     }
+ 
+-- 
+GitLab
+

--- a/plamo/03_libs/freetype/PlamoBuild.freetype-2.11.0
+++ b/plamo/03_libs/freetype/PlamoBuild.freetype-2.11.0
@@ -6,7 +6,7 @@ url="https://downloads.sourceforge.net/${pkgbase}/${pkgbase}-${vers}.tar.xz"
 digest=""
 verify="${url}.sig"
 arch=`uname -m`
-build=B1
+build=B2
 src="${pkgbase}-${vers}"
 OPT_CONFIG='--disable-static --enable-shared --enable-freetype-config'
 DOCS='ChangeLog ChangeLog.20 ChangeLog.21 ChangeLog.22 ChangeLog.23 ChangeLog.24 ChangeLog.25 ChangeLog.26 README README.git'
@@ -15,6 +15,7 @@ patchfiles="
 0002-Enable-subpixel-rendering.patch
 0003-Enable-infinality-subpixel-hinting.patch
 0004-Enable-long-PCF-family-names.patch
+0005-Restore-quiet-no_op-rendering.patch
 "
 compress=txz
 ##############################################################


### PR DESCRIPTION
fix bitmap font rederring regression

See https://gitlab.freedesktop.org/freetype/freetype/-/issues/1076