### PR TITLE
plamo/01_minimum/ca_certificate: 1.10

### DIFF
--- a/plamo/01_minimum/ca_certificate/PlamoBuild.ca_certificate-1.10
+++ b/plamo/01_minimum/ca_certificate/PlamoBuild.ca_certificate-1.10
@@ -1,11 +1,10 @@
 #!/bin/sh
 ##############################################################
 pkgbase="ca_certificate"
-script_vers="1.7"
+script_vers="1.10"
 vers="${script_vers}_$(date +%Y%m%d)"
 url="https://github.com/djlucas/make-ca/releases/download/v${script_vers}/make-ca-${script_vers}.tar.xz"
-digest="md5sum:e0356f5ae5623f227a3f69b5e8848ec6"
-cert_url="https://hg.mozilla.org/releases/mozilla-release/raw-file/default/security/nss/lib/ckfw/builtins/certdata.txt"
+digest="md5sum:74f1ad16d7a086ac76e0424fd4dfe67b"
 cacert_url=("http://www.cacert.org/certs/root.crt"
 	    "http://www.cacert.org/certs/class3.crt")
 # See http://www.cacert.org/index.php?id=3
@@ -19,7 +18,7 @@ src=""
 OPT_CONFIG='--disable-static --enable-shared'
 DOCS=''
 patchfiles=''
-compress=txz
+compress=tzst
 ##############################################################
 
 source /usr/share/plamobuild_functions.sh
@@ -47,19 +46,18 @@ else
 fi
 if [ $opt_download -eq 1 ] ; then
   download_sources
-  if [ ! -f ${cert_url##*/} ]; then
-    wget $cert_url
-  fi
 
   # CACert Certs (Class 1, Class 3)
   i=0
   for ca in ${cacert_url[@]}
   do
-      wget $ca
+      if [ ! -f ${ca##*/} ]; then
+          wget $ca
+      fi
       fp=$(openssl x509 -in ${ca##*/} -fingerprint -noout | sed -e 's/SHA1 Fingerprint=//')
       if [ "$fp" != "${cacert_fp[$i]}" ] ; then
-	  echo "The certificate fingerprint of CAcert does not match."
-	  exit 1
+          echo "The certificate fingerprint of CAcert does not match."
+          exit 1
       fi
       let i++
   done
@@ -102,7 +100,6 @@ if [ $opt_package -eq 1 ] ; then
   rm -rf -v $P/usr/lib/systemd
 
   # docdir
-  install -v -m644 $W/${cert_url##*/} $P/usr/share/doc/"$pkgbase"-"$vers"/
   install -v -m755 $W/$myname $P/usr/share/doc/"$pkgbase"-"$vers"/
   for ca in ${cacert_url[@]}
   do
@@ -111,7 +108,7 @@ if [ $opt_package -eq 1 ] ; then
 
   mkdir -p $P/install
   cat <<EOF >> $P/install/initpkg
-/usr/sbin/make-ca -C /usr/share/doc/${pkgbase}-${vers}/certdata.txt
+/usr/sbin/make-ca -g
 ( cd /etc/ssl ; ln -sf /etc/pki/tls/certs/ca-bundle.crt ca-bundle.crt )
 ( cd /etc/ssl/certs ; ln -sf /etc/pki/tls/certs/ca-bundle.crt ca-certificates.crt )
 ( cd /etc/ssl/certs ; ln -sf /etc/pki/tls/certs/ca-bundle.crt ca-bundle.crt )


### PR DESCRIPTION
certdata.txt の mozilla からの取得は make-ca コマンドが行うのでパッケージには含めなくした