### PR TITLE
plamo/07_multimedia/firefox: 100.0

### DIFF
--- a/plamo/07_multimedia/firefox/PlamoBuild.firefox-100.0
+++ b/plamo/07_multimedia/firefox/PlamoBuild.firefox-100.0
@@ -2,7 +2,7 @@
 unset LS_BLOCK_SIZE
 ##############################################################
 pkgbase='firefox'
-vers="99.0"
+vers="100.0"
 url="https://archive.mozilla.org/pub/firefox/releases/${vers}/source/firefox-${vers}.source.tar.xz"
 langpack_ja="https://ftp.mozilla.org/pub/firefox/releases/${vers}/linux-x86_64/xpi/ja.xpi"
 verify="${url}.asc"
@@ -127,6 +127,7 @@ if [ $opt_build -eq 1 ] ; then
   cd $S
   export PATH="$HOME/.cargo/bin:$PATH"
   export MOZBUILD_STATE_PATH=${PWD}/mozbuild
+  #export MACH_BUILD_PYTHON_NATIVE_PACKAGE_SOURCE=system
   export MACH_USE_SYSTEM_PYTHON=1
   export MOZ_ENABLE_FULL_SYMBOLS=1
   # disable desktop notification (? maybe...)


### PR DESCRIPTION
mach関連の設定を変えた方が良さそうだけど、とりあえずそのままでビルドは
できそうなので作成してみる。

`MACH_USE_SYSTEM_PYTHON=1` は deprecated のようなので（?）、
`MACH_BUILD_PYTHON_NATIVE_PACKAGE_SOURCE=system` とした方が良さそうだ
が、これだとpythonのモジュールが足りないと言われる。