### PR TITLE
plamo/07_multimedia/gst_plugins_good: 1.20.3

### DIFF
--- a/plamo/00_base/vim/PlamoBuild.vim-8.2.5151
+++ b/plamo/00_base/vim/PlamoBuild.vim-8.2.5151
@@ -1,7 +1,7 @@
 #!/bin/sh
 ##############################################################
 pkgbase='vim'
-vers='8.2.4929'
+vers='8.2.5151'
 url="http://github.com/vim/vim/archive/v${vers}/vim-${vers}.tar.gz"
 digest=""
 arch=`uname -m`

--- a/plamo/07_multimedia/gst_plugins_good/PlamoBuild.gst-plugins-good-1.20.3
+++ b/plamo/07_multimedia/gst_plugins_good/PlamoBuild.gst-plugins-good-1.20.3
@@ -6,7 +6,7 @@ url="https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-${v
 verify=""
 digest=""
 arch=`uname -m`
-build=B1
+build=B2
 src="gst-plugins-good-${vers}"
 OPT_CONFIG=(--buildtype=release -Dpackage-origin=https://plamolinux.org/ -Dpackage-name="GStreamer ${vers} Plamo")
 DOCS="AUTHORS COPYING ChangeLog MAINTAINERS NEWS README README.static-linking RELEASE docs meson_options.txt"


### PR DESCRIPTION
Plamo 8.x は libvpx のバージョンが異なるため、7.x に持ってきても
gst-plugins-good だけはダメなのでビルドしなおし