### PR TITLE
plamo/07_multimedia/gst_plugins_good: 1.20.3 B3

### DIFF
--- a/plamo/07_multimedia/gst_plugins_good/PlamoBuild.gst-plugins-good-1.20.3
+++ b/plamo/07_multimedia/gst_plugins_good/PlamoBuild.gst-plugins-good-1.20.3
@@ -6,7 +6,7 @@ url="https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-${v
 verify=""
 digest=""
 arch=`uname -m`
-build=B2
+build=B3
 src="gst-plugins-good-${vers}"
 OPT_CONFIG=(--buildtype=release -Dpackage-origin=https://plamolinux.org/ -Dpackage-name="GStreamer ${vers} Plamo")
 DOCS="AUTHORS COPYING ChangeLog MAINTAINERS NEWS README README.static-linking RELEASE docs meson_options.txt"


### PR DESCRIPTION
libvpxが1.11.0になったのでPlamo-8.xと同じ形にビルドし直し