### PR TITLE
plamo/00_base/shadow: 4.12.3

### DIFF
--- a/plamo/00_base/shadow/PlamoBuild.shadow-4.12.2
+++ b/plamo/00_base/shadow/PlamoBuild.shadow-4.12.2
@@ -1,15 +1,15 @@
 #!/bin/sh
 ##############################################################
 pkgbase='shadow'
-vers="4.5"
+vers="4.12.2"
 url="https://github.com/shadow-maint/shadow/releases/download/${vers}/shadow-${vers}.tar.xz"
-digest="md5sum:c350da50c2120de6bb29177699d89fe3"
+digest="md5sum:52637cb34c357acf85c617cf95da34a6"
 arch=`uname -m`
-build=B9
-src="${pkgbase}-${vers}"
-OPT_CONFIG='--sysconfdir=/etc --enable-man --without-selinux --with-libcrack --with-group-name-max-length=32'
+build=B1
+src="shadow-${vers}"
+OPT_CONFIG='--sysconfdir=/etc --without-selinux --with-libcrack --with-group-name-max-length=32'
 DOCS='ABOUT-NLS COPYING ChangeLog NEWS README TODO'
-patchfiles='disable-nls-manpages.patch'
+#patchfiles='disable-nls-manpages.patch'
 compress=txz
 ##############################################################
 # BuildRequirements:
@@ -48,7 +48,7 @@ fi
 if [ $opt_config -eq 1 ] ; then
     if [ -d $B ] ; then rm -rf $B ; fi ; cp -a $S $B
 ######################################################################
-#  don't copy sources, so need patch in the src dir
+#  copy source build, so need patch in the build dir
 ######################################################################
     cd $B
     for patch in $patchfiles ; do
@@ -147,11 +147,11 @@ if [ $opt_package -eq 1 ] ; then
   done
 
   # mkdir man dirs
-  install -dm755 -v $mandir/ja
-  for d in $( cd man/ja ; ls -d man? )
-  do
-    cp -av man/ja/$d $P/usr/share/man/ja/$d 
-  done
+  #install -dm755 -v $mandir/ja
+  #for d in $( cd man/ja ; ls -d man? )
+  #do
+  #  cp -av man/ja/$d $P/usr/share/man/ja/$d 
+  #done
 
   # initpkg
   mkdir -p $P/install

--- a/plamo/00_base/shadow/PlamoBuild.shadow-4.12.2
+++ b/plamo/00_base/shadow/PlamoBuild.shadow-4.12.2
@@ -7,7 +7,7 @@ digest="md5sum:52637cb34c357acf85c617cf95da34a6"
 arch=`uname -m`
 build=B1
 src="shadow-${vers}"
-OPT_CONFIG='--sysconfdir=/etc --without-selinux --with-libcrack --with-group-name-max-length=32'
+OPT_CONFIG='--disable-static --sysconfdir=/etc --without-selinux --with-libcrack --with-group-name-max-length=32'
 DOCS='ABOUT-NLS COPYING ChangeLog NEWS README TODO'
 #patchfiles='disable-nls-manpages.patch'
 compress=txz

--- a/plamo/00_base/shadow/PlamoBuild.shadow-4.12.2
+++ b/plamo/00_base/shadow/PlamoBuild.shadow-4.12.2
@@ -10,7 +10,7 @@ src="shadow-${vers}"
 OPT_CONFIG='--disable-static --sysconfdir=/etc --without-selinux --with-libcrack --with-group-name-max-length=32'
 DOCS='ABOUT-NLS COPYING ChangeLog NEWS README TODO'
 #patchfiles='disable-nls-manpages.patch'
-compress=txz
+compress=tzst
 ##############################################################
 # BuildRequirements:
 # plamo/05_ext/docbook.txz/libxslt

--- a/plamo/00_base/shadow/PlamoBuild.shadow-4.12.3
+++ b/plamo/00_base/shadow/PlamoBuild.shadow-4.12.3
@@ -1,9 +1,9 @@
 #!/bin/sh
 ##############################################################
 pkgbase='shadow'
-vers="4.12.2"
+vers="4.12.3"
 url="https://github.com/shadow-maint/shadow/releases/download/${vers}/shadow-${vers}.tar.xz"
-digest="md5sum:52637cb34c357acf85c617cf95da34a6"
+digest=""
 arch=`uname -m`
 build=B1
 src="shadow-${vers}"

--- a/plamo/00_base/shadow/PlamoBuild.shadow-4.12.3
+++ b/plamo/00_base/shadow/PlamoBuild.shadow-4.12.3
@@ -125,6 +125,7 @@ if [ $opt_package -eq 1 ] ; then
   cd $B
   export LDFLAGS='-Wl,--as-needed'
   make install DESTDIR=$P
+  make -C man install-man DESTDIR=$P
 
   # mv passwd from /usr/bin to /bin
   mv -v $P/usr/bin/passwd $P/bin/passwd
@@ -147,11 +148,11 @@ if [ $opt_package -eq 1 ] ; then
   done
 
   # mkdir man dirs
-  #install -dm755 -v $mandir/ja
-  #for d in $( cd man/ja ; ls -d man? )
-  #do
-  #  cp -av man/ja/$d $P/usr/share/man/ja/$d 
-  #done
+  install -dm755 -v $mandir/ja
+  for d in $( cd man/ja ; ls -d man? )
+  do
+    cp -av man/ja/$d $P/usr/share/man/ja/$d 
+  done
 
   # initpkg
   mkdir -p $P/install

--- a/plamo/00_base/shadow/adduser
+++ b/plamo/00_base/shadow/adduser
@@ -4,7 +4,7 @@
 # by Hrvoje Dogan <hdogan@student.math.hr>, Dec 1995.
 #
 # Japanese enhancements by kojima <isle@st.rim.or.jp> Aug 1997
-# Time-stamp: <2022-08-30 17:22:39 karma>
+# Time-stamp: <2022-08-30 19:59:24 karma>
 # Time-stamp: <2016-01-22 19:55:16 kojima>
 # Time-stamp: <2011-12-07 00:22:20 kojima>
 # Time-stamp: <2011-10-08 13:32:46 tamuki>
@@ -460,7 +460,7 @@ if [ -d $HME ] ; then # backup old files
   find $SKELDIR/Default -maxdepth 1 -exec backup_oldfile $HME {} \;
 fi
 
-useradd $GHME -m $GEXP $GGID $GAGID $GSHL $GUID $LOGIN
+useradd $GHME -m -k $DEFAULT_DIR $GEXP $GGID $GAGID $GSHL $GUID $LOGIN
 chmod $DEFAULT_HOME_DIR_MODE $HME
 
 echo

--- a/plamo/00_base/shadow/adduser
+++ b/plamo/00_base/shadow/adduser
@@ -4,7 +4,7 @@
 # by Hrvoje Dogan <hdogan@student.math.hr>, Dec 1995.
 #
 # Japanese enhancements by kojima <isle@st.rim.or.jp> Aug 1997
-# Time-stamp: <2018-05-29 15:03:06 karma>
+# Time-stamp: <2022-08-30 17:22:39 karma>
 # Time-stamp: <2016-01-22 19:55:16 kojima>
 # Time-stamp: <2011-12-07 00:22:20 kojima>
 # Time-stamp: <2011-10-08 13:32:46 tamuki>
@@ -169,7 +169,7 @@ msg_use_newgen_im() {
     if [ -x /usr/bin/uim-xim ] ; then
       n=$((n + 1)) ;  echo "1 : uim" ; IM[$n]="uim"
     fi
-    if [ -x /usr/bin/fcitx ] ; then
+    if [ -x /usr/bin/fcitx -o -x /usr/bin/fcitx5 ] ; then
       n=$((n + 1)) ; echo "2 : fcitx" ; IM[$n]="fcitx"
     fi
     echo -n "$LOGIN が使う IM は？ [1]: "
@@ -178,7 +178,7 @@ msg_use_newgen_im() {
     if [ -x /usr/bin/uim-xim ] ; then
       n=$((n + 1)) ;  echo "1 : uim" ; IM[$n]="uim"
     fi
-    if [ -x /usr/bin/fcitx ] ; then
+    if [ -x /usr/bin/fcitx -o -x /usr/bin/fcitx5 ] ; then
       n=$((n + 1)) ; echo "2 : fcitx" ; IM[$n]="fcitx"
     fi
     echo -n "Which IM does $LOGIN use? [1]: "


### PR DESCRIPTION
adduser スクリプトの更新
* fcitx5 に対応
* Plamo環境ではシンボリックリンクになっている/etc/skelから読めなくなっているようなのでuseradd -kで直接テンプレートディレクトリを指定（/etc/default/useraddを編集してもいい気がするけど…）