### PR TITLE
plamo/01_minimum/libmnl: 1.0.5

### DIFF
--- a/plamo/01_minimum/libmnl/PlamoBuild.libmnl-1.0.5
+++ b/plamo/01_minimum/libmnl/PlamoBuild.libmnl-1.0.5
@@ -1,7 +1,7 @@
 #!/bin/sh
 ##############################################################
 pkgbase='libmnl'
-vers='1.0.4'
+vers='1.0.5'
 url="http://www.netfilter.org/projects/${pkgbase}/files/${pkgbase}-${vers}.tar.bz2"
 verify="${url}.sig"
 arch=`uname -m`


### PR DESCRIPTION
This reverts commit 2d531c6903111fe2353db73691fdbdc5c48211a0.