### PR TITLE
plamo/07_multimedia/pulseaudit: 16.1 B2

### DIFF
--- a/plamo/07_multimedia/pulseaudio/PlamoBuild.pulseaudio-16.1
+++ b/plamo/07_multimedia/pulseaudio/PlamoBuild.pulseaudio-16.1
@@ -1,7 +1,7 @@
 #!/bin/sh
 ##############################################################
 pkgbase="pulseaudio"
-vers="15.0"
+vers="16.1"
 url="https://www.freedesktop.org/software/pulseaudio/releases/pulseaudio-${vers}.tar.xz"
 verify="${url}.sha256sum"
 digest=""


### PR DESCRIPTION
openssl 1.1.1 への依存をなくすために再ビルド