### PR TITLE
plamo/06_xapps/inkscape: 1.3.2 B2

### DIFF
--- a/plamo/06_xapps/inkscape/PlamoBuild.inkscape-1.3.2
+++ b/plamo/06_xapps/inkscape/PlamoBuild.inkscape-1.3.2
@@ -6,7 +6,7 @@ url="https://inkscape.org/gallery/item/44615/inkscape-1.3.2.tar.xz"
 verify=""
 digest="md5sum:76ed1f4b13065e80de8b2d77b6427b83"
 arch=`uname -m`
-build=B1
+build=B2
 src="inkscape-1.3.2_2023-11-25_091e20ef0f"
 OPT_CONFIG="-DCMAKE_BUILD_TYPE=Release -DMAGICK_INCLUDEDIR=/usr/include/ImageMagick-6"
 DOCS="AUTHORS COPYING INSTALL.md LICENSES NEWS.md README.md doc"

--- a/plamo/06_xapps/inkscape/PlamoBuild.inkscape-1.3.2
+++ b/plamo/06_xapps/inkscape/PlamoBuild.inkscape-1.3.2
@@ -8,7 +8,7 @@ digest="md5sum:76ed1f4b13065e80de8b2d77b6427b83"
 arch=`uname -m`
 build=B2
 src="inkscape-1.3.2_2023-11-25_091e20ef0f"
-OPT_CONFIG="-DCMAKE_BUILD_TYPE=Release -DMAGICK_INCLUDEDIR=/usr/include/ImageMagick-6"
+OPT_CONFIG="-DCMAKE_BUILD_TYPE=Release -DMAGICK_INCLUDEDIR=/usr/include/ImageMagick-6 -DWITH_INTERNAL_2GEOM=ON"
 DOCS="AUTHORS COPYING INSTALL.md LICENSES NEWS.md README.md doc"
 patchfiles="0001-fix-for-libxml2-2.12.0.patch"
 # specifies files that are not in source archive and patchfiles


### PR DESCRIPTION
lib2geom を明示的にビルドするように設定