### PR TITLE
plamo/02_devel/plamobuild: 3.5

### DIFF
--- a/plamo/02_devel/plamobuild/PlamoBuild.plamobuild-3.5
+++ b/plamo/02_devel/plamobuild/PlamoBuild.plamobuild-3.5
@@ -1,7 +1,7 @@
 #!/bin/sh
 ##############################################################
 pkgbase='plamobuild'
-vers='3.4'
+vers='3.5'
 url=("https://raw.githubusercontent.com/plamolinux/Plamo-src/plamo-8.x/admin/plamobuild_functions.sh"
      "https://raw.githubusercontent.com/plamolinux/Plamo-src/plamo-8.x/admin/make_PlamoBuild.py"
      "https://raw.githubusercontent.com/plamolinux/Plamo-src/plamo-8.x/admin/make_PlamoBuild32.py")


### PR DESCRIPTION
末尾が ".git" で終わってない git リポジトリー対応。ただし、
make_PlamoBuild.py を実行する際にネットワーク必須