### PR TITLE
contrib/network/wicd: 20251027 B2

### DIFF
--- a/contrib/network/wicd/PlamoBuild.wicd
+++ b/contrib/network/wicd/PlamoBuild.wicd
@@ -1,7 +1,7 @@
 #!/bin/sh
 ##############################################################
 pkgbase="wicd"
-commitid="1c87a01"
+commitid="c32fa28"
 vers="$(date +%Y%m%d)"
 url="https://git.launchpad.net/wicd"
 verify=""


### PR DESCRIPTION
wicdをアップデートしました。
・日本語訳の修正と追加
・トレイアイコンの修正
・ネットワーク設定を破棄するダイアログの修正