### PR TITLE
plamo/05_ext/openbox: 3.6.1 B3

### DIFF
--- a/plamo/05_ext/openbox/PlamoBuild.openbox-3.6.1
+++ b/plamo/05_ext/openbox/PlamoBuild.openbox-3.6.1
@@ -4,12 +4,12 @@ pkgbase='openbox'
 vers='3.6.1'
 url="http://${pkgbase}.org/dist/${pkgbase}/${pkgbase}-${vers}.tar.gz"
 arch=`uname -m`
-build=B1
+build=B3
 src="${pkgbase}-${vers}"
 OPT_CONFIG='--disable-static --enable-shared'
 DOCS='ABOUT-NLS AUTHORS CHANGELOG COPYING README'
-patchfiles=''
-compress=txz
+patchfiles='openbox-calc-layer.patch'
+compress=tzst
 ##############################################################
 
 source /usr/share/plamobuild_functions.sh

--- a/plamo/05_ext/openbox/openbox-calc-layer.patch
+++ b/plamo/05_ext/openbox/openbox-calc-layer.patch
@@ -1,0 +1,36 @@
+From https://bugzilla.icculus.org/show_bug.cgi?id=6669#c2
+
+diff --git a/openbox/client.c b/openbox/client.c
+index 3ff278ae..ac4ff827 100644
+--- a/openbox/client.c
++++ b/openbox/client.c
+@@ -2702,9 +2702,10 @@ static void client_calc_layer_internal(ObClient *self)
+ void client_calc_layer(ObClient *self)
+ {
+     GList *it;
++    GList *list = g_list_copy(stacking_list);
+ 
+     /* skip over stuff above fullscreen layer */
+-    for (it = stacking_list; it; it = g_list_next(it))
++    for (it = list; it; it = g_list_next(it))
+         if (window_layer(it->data) <= OB_STACKING_LAYER_FULLSCREEN) break;
+ 
+     /* find the windows in the fullscreen layer, and mark them not-visited */
+@@ -2717,7 +2718,7 @@ void client_calc_layer(ObClient *self)
+     client_calc_layer_internal(self);
+ 
+     /* skip over stuff above fullscreen layer */
+-    for (it = stacking_list; it; it = g_list_next(it))
++    for (it = list; it; it = g_list_next(it))
+         if (window_layer(it->data) <= OB_STACKING_LAYER_FULLSCREEN) break;
+ 
+     /* now recalc any windows in the fullscreen layer which have not
+@@ -2728,6 +2729,8 @@ void client_calc_layer(ObClient *self)
+                  !WINDOW_AS_CLIENT(it->data)->visited)
+             client_calc_layer_internal(it->data);
+     }
++
++    g_list_free(it);
+ }
+ 
+ gboolean client_should_show(ObClient *self)


### PR DESCRIPTION
LXQt + openboxでVLCなどをフルスクリーンで使用中に Alt + Tab でウィンドウを切り替えると、以後Alt + Tab などが効かなくなる問題の修正を行ないました。