### PR TITLE
plamo/01_minimum/ca_certificate: 1.16.1

### DIFF
--- a/plamo/01_minimum/ca_certificate/PlamoBuild.ca_certificate-1.16.1
+++ b/plamo/01_minimum/ca_certificate/PlamoBuild.ca_certificate-1.16.1
@@ -1,11 +1,11 @@
 #!/bin/sh
 ##############################################################
 pkgbase="ca_certificate"
-script_vers="1.10"
+script_vers="1.16.1"
 vers="${script_vers}_$(date +%Y%m%d)"
-url="https://github.com/lfs-book/make-ca/releases/download/v${script_vers}/make-ca-${script_vers}.tar.xz"
-digest="md5sum:74f1ad16d7a086ac76e0424fd4dfe67b"
-cert_url="https://hg.mozilla.org/releases/mozilla-release/raw-file/default/security/nss/lib/ckfw/builtins/certdata.txt"
+url="https://github.com/lfs-book/make-ca/archive/v${script_vers}/make-ca-${script_vers}.tar.gz"
+digest="md5sum:bf9cea2d24fc5344d4951b49f275c595"
+cert_url="https://hg-edge.mozilla.org/projects/nss/raw-file/tip/lib/ckfw/builtins/certdata.txt"
 cacert_url=("http://www.cacert.org/certs/root.crt"
 	    "http://www.cacert.org/certs/class3.crt")
 # See http://www.cacert.org/index.php?id=3
@@ -14,7 +14,7 @@ cacert_fp=("13:5C:EC:36:F4:9C:B8:E9:3B:1A:B2:70:CD:80:88:46:76:CE:8F:33"
 cacert_class=("1" "3")
 verify=""
 arch=`uname -m`
-build=B2
+build=B1
 src=""
 OPT_CONFIG='--disable-static --enable-shared'
 DOCS=''
@@ -92,7 +92,7 @@ if [ $opt_package -eq 1 ] ; then
       let i++
   done
 
-  cd $W/$(basename ${url##*/} .tar.xz)
+  cd $W/$(basename ${url##*/} .tar.gz)
   make install DESTDIR=$P
 
   install -v -d -m755 $P/usr/share/doc/"$pkgbase"-"$vers"/


### PR DESCRIPTION
certdata.txt の URL が変わって、make-ca -g コマンドが実行できなくなってた。